### PR TITLE
Replace FNV-1a with memhash in Map

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Concurrent data structures for Go. An extension for the standard `sync` package.
 
 This library should be considered experimental, so make sure to run tests and benchmarks for your use cases before adding it to your application.
 
+*Important note*. Only 64-bit builds are officially supported at the moment. If you need to run a 32-bit build, make sure to test it and open a GH issue in case of any problems.
+
 ### Benchmarks
 
 Benchmark results may be found [here](BENCHMARKS.md).

--- a/counter.go
+++ b/counter.go
@@ -53,7 +53,7 @@ func (c *Counter) Add(delta int64) {
 	if !ok {
 		t = new(ptoken)
 		// Since cstripes is a power of two, we can use & instead of %.
-		t.idx = hash64(uintptr(unsafe.Pointer(t))) & (cstripes - 1)
+		t.idx = uint32(hash64(uintptr(unsafe.Pointer(t))) & (cstripes - 1))
 	}
 	stripe := &c.stripes[t.idx]
 	atomic.AddInt64(&stripe.c, delta)

--- a/map.go
+++ b/map.go
@@ -311,7 +311,7 @@ func (m *Map) resize(table *mapTable, hint mapResizeHint) {
 	}
 	for i := 0; i < tableLen; i++ {
 		copied := copyBucket(&table.buckets[i], newTable)
-		addSizeNonAtomic(newTable, uint32(i), copied)
+		addSizeNonAtomic(newTable, uint64(i), copied)
 	}
 	// Publish the new table and wake up all waiters.
 	atomic.StorePointer(&m.table, unsafe.Pointer(newTable))
@@ -513,17 +513,17 @@ func derefValue(valuePtr unsafe.Pointer) interface{} {
 	return value
 }
 
-func bucketIdx(table *mapTable, hash uint64) uint32 {
-	return uint32(uint64(len(table.buckets)-1) & hash)
+func bucketIdx(table *mapTable, hash uint64) uint64 {
+	return uint64(len(table.buckets)-1) & hash
 }
 
-func addSize(table *mapTable, bucketIdx uint32, delta int) {
-	cidx := uint32(len(table.size)-1) & bucketIdx
+func addSize(table *mapTable, bucketIdx uint64, delta int) {
+	cidx := uint64(len(table.size)-1) & bucketIdx
 	atomic.AddInt64(&table.size[cidx].c, int64(delta))
 }
 
-func addSizeNonAtomic(table *mapTable, bucketIdx uint32, delta int) {
-	cidx := uint32(len(table.size)-1) & bucketIdx
+func addSizeNonAtomic(table *mapTable, bucketIdx uint64, delta int) {
+	cidx := uint64(len(table.size)-1) & bucketIdx
 	table.size[cidx].c += int64(delta)
 }
 

--- a/map.go
+++ b/map.go
@@ -125,7 +125,7 @@ func newMapTable(size int) *mapTable {
 // value is present.
 // The ok result indicates whether value was found in the map.
 func (m *Map) Load(key string) (value interface{}, ok bool) {
-	hash := fnv32(key)
+	hash := maphash64(key)
 	table := (*mapTable)(atomic.LoadPointer(&m.table))
 	bidx := bucketIdx(table, hash)
 	b := &table.buckets[bidx]
@@ -181,7 +181,7 @@ func (m *Map) doStore(key string, value interface{}, loadIfExists bool) (actual 
 		}
 	}
 	// Write path.
-	hash := fnv32(key)
+	hash := maphash64(key)
 	for {
 	store_attempt:
 		var emptykp, emptyvp *unsafe.Pointer
@@ -328,7 +328,7 @@ func copyBucket(b *bucket, destTable *mapTable) (copied int) {
 		for i := 0; i < entriesPerMapBucket; i++ {
 			if b.keys[i] != nil {
 				k := derefKey(b.keys[i])
-				hash := fnv32(k)
+				hash := maphash64(k)
 				bidx := bucketIdx(destTable, hash)
 				destb := &destTable.buckets[bidx]
 				appendToBucket(b.keys[i], b.values[i], destb)
@@ -367,7 +367,7 @@ func appendToBucket(keyPtr, valPtr unsafe.Pointer, destBucket *bucket) {
 // value if any. The loaded result reports whether the key was
 // present.
 func (m *Map) LoadAndDelete(key string) (value interface{}, loaded bool) {
-	hash := fnv32(key)
+	hash := maphash64(key)
 	for {
 		hintNonEmpty := 0
 		table := (*mapTable)(atomic.LoadPointer(&m.table))
@@ -513,8 +513,8 @@ func derefValue(valuePtr unsafe.Pointer) interface{} {
 	return value
 }
 
-func bucketIdx(table *mapTable, hash uint32) uint32 {
-	return uint32(len(table.buckets)-1) & hash
+func bucketIdx(table *mapTable, hash uint64) uint32 {
+	return uint32(uint64(len(table.buckets)-1) & hash)
 }
 
 func addSize(table *mapTable, bucketIdx uint32, delta int) {

--- a/rbmutex.go
+++ b/rbmutex.go
@@ -59,7 +59,7 @@ func (m *RBMutex) RLock() *RToken {
 		if !ok {
 			t = new(RToken)
 			// Since rslots is a power of two, we can use & instead of %.
-			t.slot = hash64(uintptr(unsafe.Pointer(t))) & (rslots - 1)
+			t.slot = uint32(hash64(uintptr(unsafe.Pointer(t))) & (rslots - 1))
 		}
 		if atomic.CompareAndSwapInt32(&m.readers[t.slot], 0, 1) {
 			if atomic.LoadInt32(&m.rbias) == 1 {

--- a/util.go
+++ b/util.go
@@ -11,7 +11,7 @@ const (
 	// memory footprint and performance; 128B usage may give ~30%
 	// improvement on NUMA machines
 	cacheLineSize = 64
-	// this seed is an absolutely arbitrary choice
+	// the seed value is of an absolutely arbitrary choice
 	maphashSeed = 42
 )
 

--- a/util.go
+++ b/util.go
@@ -11,11 +11,11 @@ const (
 )
 
 // murmurhash3 64-bit finalizer
-func hash64(x uintptr) uint32 {
+func hash64(x uintptr) uint64 {
 	x = ((x >> 33) ^ x) * 0xff51afd7ed558ccd
 	x = ((x >> 33) ^ x) * 0xc4ceb9fe1a85ec53
 	x = (x >> 33) ^ x
-	return uint32(x)
+	return uint64(x)
 }
 
 // FNV-1a 32-bit hash


### PR DESCRIPTION
Closes #7
Refs #9 

* Replaces FNV-1a 32-bit function with faster built-in 64-bit memhash function which is internally used in Golang standard library.
* Change hash64 return type. It makes no sense to trim the returned result to uint32 in hash64. Moreover, that may make hash code distribution worse.