### PR TITLE
[Experiment] Cache Map entry hash codes via tagged pointers

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -1,5 +1,7 @@
 package xsync
 
+import "unsafe"
+
 const (
 	EntriesPerMapBucket = entriesPerMapBucket
 	ResizeMapThreshold  = resizeMapThreshold
@@ -21,4 +23,24 @@ func CollectMapStats(m *Map) MapStats {
 
 func MapSize(m *Map) int {
 	return m.size()
+}
+
+func EntryHashMatch(keyPtr, valuePtr unsafe.Pointer, hash uint64) bool {
+	return entryHashMatch(keyPtr, valuePtr, hash)
+}
+
+func TagKeyPtr(key *string, hash uint64) unsafe.Pointer {
+	return tagKeyPtr(key, hash)
+}
+
+func TagValuePtr(value *interface{}, hash uint64) unsafe.Pointer {
+	return tagValuePtr(value, hash)
+}
+
+func DerefKeyPtr(keyPtr unsafe.Pointer) string {
+	return derefKeyPtr(keyPtr)
+}
+
+func DerefValuePtr(valuePtr unsafe.Pointer) interface{} {
+	return derefValuePtr(valuePtr)
 }


### PR DESCRIPTION
Refs: #2

In short, I got a consistent ~10% improvement in Map benchmarks, but pointer tagging does not conform to valid (i.e. safe for future version changes) unsafe.Pointer conversions: https://pkg.go.dev/unsafe#Pointer

Another tricky part is that the hard coded parts assume 64-bit arch.

**Update**. Hash code caching was implemented in #31.