### PR TITLE
[Experiment] Epoch-based map

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -2,7 +2,6 @@ package xsync
 
 const (
 	EntriesPerMapBucket = entriesPerMapBucket
-	ResizeMapThreshold  = resizeMapThreshold
 	MinMapTableLen      = minMapTableLen
 	MaxMapCounterLen    = maxMapCounterLen
 )


### PR DESCRIPTION
Refs: #8

* Swaps atomic snapshots from vanilla CLHT with epoch-based snapshots described in #8
* Value pointer uniqueness required by atomic snapshots is no longer needed. So, the Map can be easily adapted to store arbitrary types, not only `interface{}`
* `nilVal` tag struct was removed since it's now possible to store `nil` values for existing map entries directly in the bucket
* Bucket linked lists are removed in favor of increasing the bucket size to 2 CL (128B). This means up to 7 entries per bucket vs. 9 entries in the baseline implementation
* Keys and values are now stored in a single array, so that each key and the corresponding value are located in the same CL

With this snapshots design, only around 2% of snapshot attempts fail (i.e. require another spin) in scenario with 1 reader and 4 writer goroutines. In 1/1 scenario the proportion goes down to 0.15%.

The performance is slightly better (~10%) than the baseline in warmed-up cases. However, the Range operation got ~30-50% slower (#25 may fix that)