### PR TITLE
Remove bucket chaining from Map

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -2,7 +2,6 @@ package xsync
 
 const (
 	EntriesPerMapBucket = entriesPerMapBucket
-	ResizeMapThreshold  = resizeMapThreshold
 	MinMapTableLen      = minMapTableLen
 	MaxMapCounterLen    = maxMapCounterLen
 )

--- a/export_test.go
+++ b/export_test.go
@@ -21,3 +21,15 @@ func CollectMapStats(m *Map) MapStats {
 func MapSize(m *Map) int {
 	return m.size()
 }
+
+func TopHashMatch(hash, topHashes uint64, idx int) bool {
+	return topHashMatch(hash, topHashes, idx)
+}
+
+func StoreTopHash(hash, topHashes uint64, idx int) uint64 {
+	return storeTopHash(hash, topHashes, idx)
+}
+
+func EraseTopHash(topHashes uint64, idx int) uint64 {
+	return eraseTopHash(topHashes, idx)
+}


### PR DESCRIPTION
Closes #2

* Removes linked lists from Map buckets
  - Also increases bucket size to fit 7 entries (2 CLs). So, when compared with the current Map maximum number of entries in bucket decrease from 9 to 7 entries. On the other hand, spacial locality and data density improved
* Adds a cache with top bytes of entry hash codes
  - Improves key lookup efficiency by caching one most significant byte of each map entry. This way string dereference and equality check is avoided for a significant portion of scanned entries
* Decreases the shrink threshold fraction proportionally to the new map layout

### Benchmark results

Here is the result of comparison with current `main` (v1.0.2) on my laptop (Ubuntu 20.04, i5-8300h, Go 1.17)
```bash
$ benchstat old.txt new.txt
name                      old time/op  new time/op  delta
Map_NoWarmUp/99%-reads-8  45.5ns ± 2%  33.5ns ± 0%  -26.31%  (p=0.008 n=5+5)
Map_NoWarmUp/90%-reads-8  59.0ns ± 3%  46.7ns ± 1%  -20.90%  (p=0.008 n=5+5)
Map_NoWarmUp/75%-reads-8  71.4ns ±23%  56.1ns ± 1%  -21.41%  (p=0.016 n=5+4)
Map_NoWarmUp/50%-reads-8  77.3ns ± 4%  77.2ns ±25%     ~     (p=0.690 n=5+5)
Map_NoWarmUp/0%-reads-8    102ns ±34%    94ns ±10%     ~     (p=1.000 n=5+5)
Map_WarmUp/100%-reads-8   64.4ns ± 0%  56.4ns ± 0%  -12.41%  (p=0.008 n=5+5)
Map_WarmUp/99%-reads-8    64.0ns ± 0%  55.8ns ± 0%  -12.77%  (p=0.008 n=5+5)
Map_WarmUp/90%-reads-8    64.7ns ± 0%  53.2ns ± 0%  -17.83%  (p=0.008 n=5+5)
Map_WarmUp/75%-reads-8    64.5ns ± 0%  53.0ns ± 0%  -17.92%  (p=0.029 n=4+4)
Map_WarmUp/50%-reads-8    68.2ns ± 9%  56.8ns ± 0%  -16.76%  (p=0.016 n=5+4)
Map_WarmUp/0%-reads-8     80.4ns ± 1%  69.3ns ± 1%  -13.79%  (p=0.016 n=5+4)
```