### PR TITLE
LoadOrStore: actually return the given value

### DIFF
--- a/map.go
+++ b/map.go
@@ -169,6 +169,7 @@ func (m *Map) doStore(key string, value interface{}, loadIfExists bool) (actual 
 	if value == nil {
 		value = nilVal
 	}
+	actual = value
 	// Read-only path.
 	if loadIfExists {
 		if v, ok := m.Load(key); ok {

--- a/map_test.go
+++ b/map_test.go
@@ -100,6 +100,19 @@ func TestMapLoadOrStore_NilValue(t *testing.T) {
 	}
 }
 
+func TestMapLoadOrStore_NonNilValue(t *testing.T) {
+	type foo struct{}
+	m := NewMap()
+	newv := &foo{}
+	v, loaded := m.LoadOrStore("foo", newv)
+	if loaded {
+		t.Error("no value was expected")
+	}
+	if v != newv {
+		t.Errorf("value was not newv: %v", v)
+	}
+}
+
 func TestMapRange(t *testing.T) {
 	const numEntries = 1000
 	m := NewMap()
@@ -579,8 +592,8 @@ func benchmarkMap(
 	loadFn func(k string) (interface{}, bool),
 	storeFn func(k string, v interface{}),
 	deleteFn func(k string),
-	readPercentage int) {
-
+	readPercentage int,
+) {
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		r := rand.New(rand.NewSource(time.Now().UnixNano()))

--- a/mapof.go
+++ b/mapof.go
@@ -103,6 +103,7 @@ func (m *MapOf[V]) doStore(key string, value V, loadIfExists bool) (actual V, lo
 			return v, true
 		}
 	}
+	actual = value
 	// Write path.
 	hash := maphash64(key)
 	for {

--- a/mapof_test.go
+++ b/mapof_test.go
@@ -4,11 +4,12 @@
 package xsync_test
 
 import (
-	. "github.com/puzpuzpuz/xsync"
 	"math/rand"
 	"strconv"
 	"testing"
 	"time"
+
+	. "github.com/puzpuzpuz/xsync"
 )
 
 func TestMapOf_MissingEntry(t *testing.T) {
@@ -58,6 +59,19 @@ func TestMapOfLoadOrStore_NilValue(t *testing.T) {
 	}
 	if v != nil {
 		t.Errorf("value was not nil: %v", v)
+	}
+}
+
+func TestMapOfLoadOrStore_NonNilValue(t *testing.T) {
+	type foo struct{}
+	m := NewMapOf[*foo]()
+	newv := &foo{}
+	v, loaded := m.LoadOrStore("foo", newv)
+	if loaded {
+		t.Error("no value was expected")
+	}
+	if v != newv {
+		t.Errorf("value was not newv: %v", v)
 	}
 }
 
@@ -430,8 +444,8 @@ func benchmarkMapInt(
 	loadFn func(k string) (int, bool),
 	storeFn func(k string, v int),
 	deleteFn func(k string),
-	readPercentage int) {
-
+	readPercentage int,
+) {
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		r := rand.New(rand.NewSource(time.Now().UnixNano()))


### PR DESCRIPTION
The method docs for `LoadOrStore` mention:
> it stores and returns the given value

but the current implementation does not return the provided value when `!loaded`.

Maybe I'm overlooking something obvious? :thinking: 