### PR TITLE
Remove obsolete docs on Map and MapOf shrink behavior

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x]
+        go-version: [1.17.x]
     name: Build with Go ${{ matrix.go-version }}
     steps:
       - uses: actions/checkout@v2.3.4

--- a/map_test.go
+++ b/map_test.go
@@ -109,7 +109,7 @@ func TestMapLoadOrStore_NonNilValue(t *testing.T) {
 		t.Error("no value was expected")
 	}
 	if v != newv {
-		t.Errorf("value was not newv: %v", v)
+		t.Errorf("value does not match: %v", v)
 	}
 }
 

--- a/mapof_test.go
+++ b/mapof_test.go
@@ -71,7 +71,7 @@ func TestMapOfLoadOrStore_NonNilValue(t *testing.T) {
 		t.Error("no value was expected")
 	}
 	if v != newv {
-		t.Errorf("value was not newv: %v", v)
+		t.Errorf("value does not match: %v", v)
 	}
 }
 


### PR DESCRIPTION
Addresses https://github.com/puzpuzpuz/xsync/issues/5#issuecomment-1089936881

Also simplifies `doStore` methods