### PR TITLE
Use hash/maphash instead of go:linkname hacks

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,32 @@
+package xsync_test
+
+import (
+	"encoding/binary"
+	"hash/maphash"
+	"time"
+
+	"github.com/puzpuzpuz/xsync"
+)
+
+func ExampleNewTypedMapOf() {
+	type Person struct {
+		GivenName   string
+		FamilyName  string
+		YearOfBirth int
+	}
+	age := xsync.NewTypedMapOf[Person, int](func(seed maphash.Seed, p Person) uint64 {
+		var h maphash.Hash
+		h.SetSeed(seed)
+		// We write field numbers, to make sure that "foo", "bar" and "foob", "ar" hash differently.
+		h.WriteByte(0)
+		h.WriteString(p.GivenName)
+		h.WriteByte(1)
+		h.WriteString(p.FamilyName)
+		h.WriteByte(2)
+		binary.Write(&h, binary.LittleEndian, p.YearOfBirth)
+		return h.Sum64()
+	})
+	Y := time.Now().Year()
+	age.Store(Person{"Ada", "Lovelace", 1815}, Y-1815)
+	age.Store(Person{"Charles", "Babbage", 1791}, Y-1791)
+}

--- a/util.go
+++ b/util.go
@@ -1,8 +1,7 @@
 package xsync
 
 import (
-	"reflect"
-	"unsafe"
+	"hash/maphash"
 )
 
 // test-only assert()-like flag
@@ -14,12 +13,6 @@ const (
 	// memory footprint and performance; 128B usage may give ~30%
 	// improvement on NUMA machines
 	cacheLineSize = 64
-)
-
-var (
-	s1          = uint64(fastrand())
-	s2          = uint64(fastrand())
-	maphashSeed = uintptr(s1<<32 + s2)
 )
 
 // murmurhash3 64-bit finalizer
@@ -41,23 +34,10 @@ func mixhash64(v uint64) uint64 {
 	return v
 }
 
-// StrHash64 is the built-in string hash function.
-// It might be handy when writing a hasher function for NewTypedMapOf.
-//
-// Returned hash codes are is local to a single process and cannot
-// be recreated in a different process.
-func StrHash64(s string) uint64 {
-	if s == "" {
-		return uint64(maphashSeed)
-	}
-	strh := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	return uint64(memhash(unsafe.Pointer(strh.Data), maphashSeed, uintptr(strh.Len)))
+// hashString calculates a hash of s with the given seed.
+func hashString(seed maphash.Seed, s string) uint64 {
+	var h maphash.Hash
+	h.SetSeed(seed)
+	h.WriteString(s)
+	return h.Sum64()
 }
-
-//go:noescape
-//go:linkname memhash runtime.memhash
-func memhash(p unsafe.Pointer, h, s uintptr) uintptr
-
-//go:noescape
-//go:linkname fastrand runtime.fastrand
-func fastrand() uint32


### PR DESCRIPTION
This PR has two commits. The first is using maphash only as an implementation detail, without any API changes. The second commit makes the usage of `maphash` part of the API, which would simplify implementing good hash functions for custom types.