### PR TITLE
Improve map Range benchmarks

### DIFF
--- a/map_test.go
+++ b/map_test.go
@@ -978,6 +978,9 @@ func BenchmarkMapRange(b *testing.B) {
 		foo := 0
 		for pb.Next() {
 			m.Range(func(key string, value interface{}) bool {
+				// Dereference the value to have an apple-to-apple
+				// comparison with MapOf.Range.
+				_ = value.(int)
 				foo++
 				return true
 			})
@@ -996,6 +999,9 @@ func BenchmarkMapRangeStandard(b *testing.B) {
 		foo := 0
 		for pb.Next() {
 			m.Range(func(key interface{}, value interface{}) bool {
+				// Dereference the key and the value to have an apple-to-apple
+				// comparison with MapOf.Range.
+				_, _ = key.(string), value.(int)
 				foo++
 				return true
 			})


### PR DESCRIPTION
1M string/int entries:
```
$ go test -benchmem -run=^$ -bench Range
goos: linux
goarch: amd64
pkg: github.com/puzpuzpuz/xsync/v2
cpu: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
BenchmarkMapRange-8           	     158	   7411077 ns/op	       6 B/op	       0 allocs/op
BenchmarkMapRangeStandard-8   	      62	  18308102 ns/op	      11 B/op	       0 allocs/op
BenchmarkMapOfRange-8         	      82	  12645228 ns/op	       9 B/op	       0 allocs/op
PASS
ok  	github.com/puzpuzpuz/xsync/v2	10.727s
```

64 string/int entries:
```
$ go test -benchmem -run=^$ -bench Range
goos: linux
goarch: amd64
pkg: github.com/puzpuzpuz/xsync/v2
cpu: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
BenchmarkMapRange-8           	15090876	        76.98 ns/op	       0 B/op	       0 allocs/op
BenchmarkMapRangeStandard-8   	 8648931	       140.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkMapOfRange-8         	15457384	        75.70 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/puzpuzpuz/xsync/v2	3.855s
```