### PR TITLE
Optimize Counter thread-to-stripe distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Benchmark results may be found [here](BENCHMARKS.md).
 
 ## Counter
 
-A `Counter` is a striped `int64` counter inspired by the j.u.c.a.LongAdder class from Java standard library.
+A `Counter` is a striped `int64` counter inspired by the `j.u.c.a.LongAdder` class from Java standard library.
 
 ```go
-var c xsync.Counter
+c := xsync.NewCounter()
 // increment and decrement the counter
 c.Inc()
 c.Dec()
@@ -23,7 +23,7 @@ c.Dec()
 v := c.Value()
 ```
 
-Works better in comparison with a single atomically updated int64 counter in high contention scenarios.
+Works better in comparison with a single atomically updated `int64` counter in high contention scenarios.
 
 ## Map
 

--- a/counter_test.go
+++ b/counter_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestCounterInc(t *testing.T) {
-	var c Counter
+	c := NewCounter()
 	for i := 0; i < 100; i++ {
 		if v := c.Value(); v != int64(i) {
 			t.Fatalf("got %v, want %d", v, i)
@@ -19,7 +19,7 @@ func TestCounterInc(t *testing.T) {
 }
 
 func TestCounterDec(t *testing.T) {
-	var c Counter
+	c := NewCounter()
 	for i := 0; i < 100; i++ {
 		if v := c.Value(); v != int64(-i) {
 			t.Fatalf("got %v, want %d", v, -i)
@@ -29,7 +29,7 @@ func TestCounterDec(t *testing.T) {
 }
 
 func TestCounterAdd(t *testing.T) {
-	var c Counter
+	c := NewCounter()
 	for i := 0; i < 100; i++ {
 		if v := c.Value(); v != int64(i*42) {
 			t.Fatalf("got %v, want %d", v, i*42)
@@ -39,7 +39,7 @@ func TestCounterAdd(t *testing.T) {
 }
 
 func TestCounterReset(t *testing.T) {
-	var c Counter
+	c := NewCounter()
 	c.Add(42)
 	if v := c.Value(); v != 42 {
 		t.Fatalf("got %v, want %d", v, 42)
@@ -59,11 +59,11 @@ func parallelIncrementor(c *Counter, numIncs int, cdone chan bool) {
 
 func doTestParallelIncrementors(t *testing.T, numModifiers, gomaxprocs int) {
 	runtime.GOMAXPROCS(gomaxprocs)
-	var c Counter
+	c := NewCounter()
 	cdone := make(chan bool)
 	numIncs := 10000
 	for i := 0; i < numModifiers; i++ {
-		go parallelIncrementor(&c, numIncs, cdone)
+		go parallelIncrementor(c, numIncs, cdone)
 	}
 	// Wait for the goroutines to finish.
 	for i := 0; i < numModifiers; i++ {
@@ -83,7 +83,7 @@ func TestCounterParallelIncrementors(t *testing.T) {
 }
 
 func benchmarkCounter(b *testing.B, writeRatio int) {
-	var c Counter
+	c := NewCounter()
 	b.RunParallel(func(pb *testing.PB) {
 		foo := 0
 		for pb.Next() {

--- a/rbmutex.go
+++ b/rbmutex.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-	"unsafe"
 )
 
 const (
@@ -59,7 +58,7 @@ func (m *RBMutex) RLock() *RToken {
 		if !ok {
 			t = new(RToken)
 			// Since rslots is a power of two, we can use & instead of %.
-			t.slot = uint32(mixhash64(uintptr(unsafe.Pointer(t))) & (rslots - 1))
+			t.slot = uint32(fastrand() & (rslots - 1))
 		}
 		if atomic.CompareAndSwapInt32(&m.readers[t.slot], 0, 1) {
 			if atomic.LoadInt32(&m.rbias) == 1 {

--- a/util.go
+++ b/util.go
@@ -2,6 +2,8 @@ package xsync
 
 import (
 	"hash/maphash"
+	"runtime"
+	_ "unsafe"
 )
 
 // test-only assert()-like flag
@@ -15,15 +17,6 @@ const (
 	cacheLineSize = 64
 )
 
-// mixhash64 is murmurhash3 64-bit finalizer.
-func mixhash64(v uintptr) uint64 {
-	x := uint64(v)
-	x = ((x >> 33) ^ x) * 0xff51afd7ed558ccd
-	x = ((x >> 33) ^ x) * 0xc4ceb9fe1a85ec53
-	x = (x >> 33) ^ x
-	return x
-}
-
 // hashString calculates a hash of s with the given seed.
 func hashString(seed maphash.Seed, s string) uint64 {
 	var h maphash.Hash
@@ -31,3 +24,29 @@ func hashString(seed maphash.Seed, s string) uint64 {
 	h.WriteString(s)
 	return h.Sum64()
 }
+
+// nextPowOf2 computes the next highest power of 2 of 32-bit v.
+// Source: https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+func nextPowOf2(v uint32) uint32 {
+	v--
+	v |= v >> 1
+	v |= v >> 2
+	v |= v >> 4
+	v |= v >> 8
+	v |= v >> 16
+	v++
+	return v
+}
+
+func parallelism() uint32 {
+	maxProcs := uint32(runtime.GOMAXPROCS(0))
+	numCores := uint32(runtime.NumCPU())
+	if maxProcs < numCores {
+		return maxProcs
+	}
+	return numCores
+}
+
+//go:noescape
+//go:linkname fastrand runtime.fastrand
+func fastrand() uint32


### PR DESCRIPTION
* The number of stripes is now calculated dynamically based on the number of cores and GOMAXPROCS
* The performance is close enough to the old one with 64 stripes while the memory footprint is significantly lower and, what's also important, unlucky distribution isn't a problem anymore

Note: this is a breaking change due to the new `NewCounter` method.