### PR TITLE
Fix counter index on dynamically set number of CPUs

### DIFF
--- a/counter.go
+++ b/counter.go
@@ -59,16 +59,14 @@ func (c *Counter) Add(delta int64) {
 	t, ok := ptokenPool.Get().(*ptoken)
 	if !ok {
 		t = new(ptoken)
-		t.idx = fastrand() & c.mask
 	}
+	t.idx = fastrand() & c.mask
 	for {
 		stripe := &c.stripes[t.idx]
 		cnt := atomic.LoadInt64(&stripe.c)
 		if atomic.CompareAndSwapInt64(&stripe.c, cnt, cnt+delta) {
 			break
 		}
-		// Give a try with another randomly selected stripe.
-		t.idx = fastrand() & c.mask
 	}
 	ptokenPool.Put(t)
 }

--- a/counter_test.go
+++ b/counter_test.go
@@ -51,7 +51,7 @@ func TestCounterReset(t *testing.T) {
 }
 
 func parallelIncrementor(c *Counter, numIncs int, cdone chan bool) {
-	for i := 0; i < 10000; i++ {
+	for i := 0; i < numIncs; i++ {
 		c.Inc()
 	}
 	cdone <- true


### PR DESCRIPTION
Error found when testing on WSL 1.
Reason: Inappropriate index values may remain in the global ptokenPool.

**Before**

root@fufuok:/mnt/e/Go/fufuok/xsync# for i in $(seq 1 5); do go test -run=TestCounter -count=1; done
PASS
ok      github.com/puzpuzpuz/xsync/v2   0.129s
panic: runtime error: index out of range [14] with length 2

goroutine 32 [running]:
github.com/puzpuzpuz/xsync/v2.(*Counter).Add(0xc0052f40a0, 0x1)
        /mnt/e/Go/fufuok/xsync/counter.go:65 +0xe5
github.com/puzpuzpuz/xsync/v2.(*Counter).Inc(...)
        /mnt/e/Go/fufuok/xsync/counter.go:49
github.com/puzpuzpuz/xsync/v2_test.parallelIncrementor(0x0?, 0x0?, 0x0?)
        /mnt/e/Go/fufuok/xsync/counter_test.go:55 +0x32
created by github.com/puzpuzpuz/xsync/v2_test.doTestParallelIncrementors
        /mnt/e/Go/fufuok/xsync/counter_test.go:66 +0x56
exit status 2
FAIL    github.com/puzpuzpuz/xsync/v2   0.133s
PASS
ok      github.com/puzpuzpuz/xsync/v2   0.132s
panic: runtime error: index out of range [11] with length 2

goroutine 52 [running]:
github.com/puzpuzpuz/xsync/v2.(*Counter).Add(0xc00523e0a0, 0x1)
        /mnt/e/Go/fufuok/xsync/counter.go:65 +0xe5
github.com/puzpuzpuz/xsync/v2.(*Counter).Inc(...)
        /mnt/e/Go/fufuok/xsync/counter.go:49
github.com/puzpuzpuz/xsync/v2_test.parallelIncrementor(0x0?, 0x0?, 0x0?)
        /mnt/e/Go/fufuok/xsync/counter_test.go:55 +0x32
created by github.com/puzpuzpuz/xsync/v2_test.doTestParallelIncrementors
        /mnt/e/Go/fufuok/xsync/counter_test.go:66 +0x56
exit status 2
FAIL    github.com/puzpuzpuz/xsync/v2   0.133s
panic: runtime error: index out of range [2] with length 2

goroutine 49 [running]:
github.com/puzpuzpuz/xsync/v2.(*Counter).Add(0xc00527c0a0, 0x1)
        /mnt/e/Go/fufuok/xsync/counter.go:65 +0xe5
github.com/puzpuzpuz/xsync/v2.(*Counter).Inc(...)
        /mnt/e/Go/fufuok/xsync/counter.go:49
github.com/puzpuzpuz/xsync/v2_test.parallelIncrementor(0x0?, 0x0?, 0x0?)
        /mnt/e/Go/fufuok/xsync/counter_test.go:55 +0x32
created by github.com/puzpuzpuz/xsync/v2_test.doTestParallelIncrementors
        /mnt/e/Go/fufuok/xsync/counter_test.go:66 +0x56
exit status 2
FAIL    github.com/puzpuzpuz/xsync/v2   0.130s

**After**

root@fufuok:/mnt/e/Go/fufuok/xsync# for i in $(seq 1 5); do go test -run=TestCounter -count=1; done
PASS
ok      github.com/puzpuzpuz/xsync/v2   0.140s
PASS
ok      github.com/puzpuzpuz/xsync/v2   0.140s
PASS
ok      github.com/puzpuzpuz/xsync/v2   0.139s
PASS
ok      github.com/puzpuzpuz/xsync/v2   0.139s
PASS
ok      github.com/puzpuzpuz/xsync/v2   0.137s