### PR TITLE
Optimize RBMutex footprint and thread-to-slot distribution

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -7,7 +7,7 @@ $ go test -bench .
 
 To limit the number of used CPU cores append `-cpu=<number>` argument to the above command.
 
-This document contains some benchmark results obtained on a cloud VM.
+This document contains some benchmark results obtained for xsync v1.0.0 on a cloud VM.
 
 ### Counter vs. atomic int64
 

--- a/README.md
+++ b/README.md
@@ -101,17 +101,17 @@ To get the optimal performance, you may want to set the queue size to be large e
 A `RBMutex` is a reader biased reader/writer mutual exclusion lock. The lock can be held by an many readers or a single writer.
 
 ```go
-var m xsync.RBMutex
+mu := xsync.NewRBMutex()
 // reader lock calls return a token
-t := m.RLock()
+t := mu.RLock()
 // the token must be later used to unlock the mutex
-m.RUnlock(t)
+mu.RUnlock(t)
 // writer locks are the same as in sync.RWMutex
-m.Lock()
-m.Unlock()
+mu.Lock()
+mu.Unlock()
 ```
 
-`RBMutex` is based on the BRAVO (Biased Locking for Reader-Writer Locks) algorithm: https://arxiv.org/pdf/1810.01553.pdf
+`RBMutex` is based on a modified version of BRAVO (Biased Locking for Reader-Writer Locks) algorithm: https://arxiv.org/pdf/1810.01553.pdf
 
 The idea of the algorithm is to build on top of an existing reader-writer mutex and introduce a fast path for readers. On the fast path, reader lock attempts are sharded over an internal array based on the reader identity (a token in case of Golang). This means that readers do not contend over a single atomic counter like it's done in, say, `sync.RWMutex` allowing for better scalability in terms of cores.
 

--- a/counter.go
+++ b/counter.go
@@ -16,6 +16,8 @@ var ptokenPool sync.Pool
 // the counter
 type ptoken struct {
 	idx uint32
+	//lint:ignore U1000 prevents false sharing
+	pad [cacheLineSize - 4]byte
 }
 
 // A Counter is a striped int64 counter.
@@ -35,6 +37,7 @@ type cstripe struct {
 	pad [cacheLineSize - 8]byte
 }
 
+// NewCounter creates a new Counter instance.
 func NewCounter() *Counter {
 	nstripes := nextPowOf2(parallelism())
 	c := Counter{

--- a/rbmutex_test.go
+++ b/rbmutex_test.go
@@ -132,8 +132,9 @@ func TestRBMutex(t *testing.T) {
 	hammerRBMutex(10, 5, n)
 }
 
-func benchmarkRBMutex(b *testing.B, localWork, writeRatio int) {
+func benchmarkRBMutex(b *testing.B, parallelism, localWork, writeRatio int) {
 	mu := NewRBMutex()
+	b.SetParallelism(parallelism)
 	b.RunParallel(func(pb *testing.PB) {
 		foo := 0
 		for pb.Next() {
@@ -158,40 +159,45 @@ func benchmarkRBMutex(b *testing.B, localWork, writeRatio int) {
 	})
 }
 
+func BenchmarkRBMutexReadOnly_HighParallelism(b *testing.B) {
+	benchmarkRBMutex(b, 1024, 0, -1)
+}
+
 func BenchmarkRBMutexReadOnly(b *testing.B) {
-	benchmarkRBMutex(b, 0, -1)
+	benchmarkRBMutex(b, -1, 0, -1)
 }
 
 func BenchmarkRBMutexWrite100000(b *testing.B) {
-	benchmarkRBMutex(b, 0, 100000)
+	benchmarkRBMutex(b, -1, 0, 100000)
 }
 
 func BenchmarkRBMutexWrite10000(b *testing.B) {
-	benchmarkRBMutex(b, 0, 10000)
+	benchmarkRBMutex(b, -1, 0, 10000)
 }
 
 func BenchmarkRBMutexWrite1000(b *testing.B) {
-	benchmarkRBMutex(b, 0, 1000)
+	benchmarkRBMutex(b, -1, 0, 1000)
 }
 
 func BenchmarkRBMutexWorkReadOnly(b *testing.B) {
-	benchmarkRBMutex(b, 100, -1)
+	benchmarkRBMutex(b, -1, 100, -1)
 }
 
 func BenchmarkRBMutexWorkWrite100000(b *testing.B) {
-	benchmarkRBMutex(b, 100, 100000)
+	benchmarkRBMutex(b, -1, 100, 100000)
 }
 
 func BenchmarkRBMutexWorkWrite10000(b *testing.B) {
-	benchmarkRBMutex(b, 100, 10000)
+	benchmarkRBMutex(b, -1, 100, 10000)
 }
 
 func BenchmarkRBMutexWorkWrite1000(b *testing.B) {
-	benchmarkRBMutex(b, 100, 1000)
+	benchmarkRBMutex(b, -1, 100, 1000)
 }
 
-func benchmarkRWMutex(b *testing.B, localWork, writeRatio int) {
+func benchmarkRWMutex(b *testing.B, parallelism, localWork, writeRatio int) {
 	var mu sync.RWMutex
+	b.SetParallelism(parallelism)
 	b.RunParallel(func(pb *testing.PB) {
 		foo := 0
 		for pb.Next() {
@@ -216,34 +222,38 @@ func benchmarkRWMutex(b *testing.B, localWork, writeRatio int) {
 	})
 }
 
+func BenchmarkRWMutexReadOnly_HighParallelism(b *testing.B) {
+	benchmarkRWMutex(b, 1024, 0, -1)
+}
+
 func BenchmarkRWMutexReadOnly(b *testing.B) {
-	benchmarkRWMutex(b, 0, -1)
+	benchmarkRWMutex(b, -1, 0, -1)
 }
 
 func BenchmarkRWMutexWrite100000(b *testing.B) {
-	benchmarkRWMutex(b, 0, 100000)
+	benchmarkRWMutex(b, -1, 0, 100000)
 }
 
 func BenchmarkRWMutexWrite10000(b *testing.B) {
-	benchmarkRWMutex(b, 0, 10000)
+	benchmarkRWMutex(b, -1, 0, 10000)
 }
 
 func BenchmarkRWMutexWrite1000(b *testing.B) {
-	benchmarkRWMutex(b, 0, 1000)
+	benchmarkRWMutex(b, -1, 0, 1000)
 }
 
 func BenchmarkRWMutexWorkReadOnly(b *testing.B) {
-	benchmarkRWMutex(b, 100, -1)
+	benchmarkRWMutex(b, -1, 100, -1)
 }
 
 func BenchmarkRWMutexWorkWrite100000(b *testing.B) {
-	benchmarkRWMutex(b, 100, 100000)
+	benchmarkRWMutex(b, -1, 100, 100000)
 }
 
 func BenchmarkRWMutexWorkWrite10000(b *testing.B) {
-	benchmarkRWMutex(b, 100, 10000)
+	benchmarkRWMutex(b, -1, 100, 10000)
 }
 
 func BenchmarkRWMutexWorkWrite1000(b *testing.B) {
-	benchmarkRWMutex(b, 100, 1000)
+	benchmarkRWMutex(b, -1, 100, 1000)
 }

--- a/rbmutex_test.go
+++ b/rbmutex_test.go
@@ -15,29 +15,34 @@ import (
 )
 
 func TestRBMutexSerialReader(t *testing.T) {
-	var m RBMutex
-	for i := 0; i < 10; i++ {
-		tk := m.RLock()
-		m.RUnlock(tk)
+	const numIters = 10
+	mu := NewRBMutex()
+	var rtokens [numIters]*RToken
+	for i := 0; i < numIters; i++ {
+		rtokens[i] = mu.RLock()
+
+	}
+	for i := 0; i < numIters; i++ {
+		mu.RUnlock(rtokens[i])
 	}
 }
 
-func parallelReader(m *RBMutex, clocked, cunlock, cdone chan bool) {
-	tk := m.RLock()
+func parallelReader(mu *RBMutex, clocked, cunlock, cdone chan bool) {
+	tk := mu.RLock()
 	clocked <- true
 	<-cunlock
-	m.RUnlock(tk)
+	mu.RUnlock(tk)
 	cdone <- true
 }
 
 func doTestParallelReaders(numReaders, gomaxprocs int) {
 	runtime.GOMAXPROCS(gomaxprocs)
-	var m RBMutex
+	mu := NewRBMutex()
 	clocked := make(chan bool)
 	cunlock := make(chan bool)
 	cdone := make(chan bool)
 	for i := 0; i < numReaders; i++ {
-		go parallelReader(&m, clocked, cunlock, cdone)
+		go parallelReader(mu, clocked, cunlock, cdone)
 	}
 	// Wait for all parallel RLock()s to succeed.
 	for i := 0; i < numReaders; i++ {
@@ -53,60 +58,58 @@ func doTestParallelReaders(numReaders, gomaxprocs int) {
 }
 
 func TestRBMutexParallelReaders(t *testing.T) {
-	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(-1))
+	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(0))
 	doTestParallelReaders(1, 4)
 	doTestParallelReaders(3, 4)
 	doTestParallelReaders(4, 2)
 }
 
-func reader(m *RBMutex, numIterations int, activity *int32, cdone chan bool) {
+func reader(mu *RBMutex, numIterations int, activity *int32, cdone chan bool) {
 	for i := 0; i < numIterations; i++ {
-		tk := m.RLock()
+		tk := mu.RLock()
 		n := atomic.AddInt32(activity, 1)
 		if n < 1 || n >= 10000 {
-			m.RUnlock(tk)
+			mu.RUnlock(tk)
 			panic(fmt.Sprintf("rlock(%d)\n", n))
 		}
 		for i := 0; i < 100; i++ {
 		}
 		atomic.AddInt32(activity, -1)
-		m.RUnlock(tk)
+		mu.RUnlock(tk)
 	}
 	cdone <- true
 }
 
-func writer(m *RBMutex, numIterations int, activity *int32, cdone chan bool) {
+func writer(mu *RBMutex, numIterations int, activity *int32, cdone chan bool) {
 	for i := 0; i < numIterations; i++ {
-		m.Lock()
+		mu.Lock()
 		n := atomic.AddInt32(activity, 10000)
 		if n != 10000 {
-			m.Unlock()
+			mu.Unlock()
 			panic(fmt.Sprintf("wlock(%d)\n", n))
 		}
 		for i := 0; i < 100; i++ {
 		}
 		atomic.AddInt32(activity, -10000)
-		m.Unlock()
+		mu.Unlock()
 	}
 	cdone <- true
 }
 
 func hammerRBMutex(gomaxprocs, numReaders, numIterations int) {
 	runtime.GOMAXPROCS(gomaxprocs)
-	var (
-		// Number of active readers + 10000 * number of active writers.
-		activity int32
-		m        RBMutex
-	)
+	// Number of active readers + 10000 * number of active writers.
+	var activity int32
+	mu := NewRBMutex()
 	cdone := make(chan bool)
-	go writer(&m, numIterations, &activity, cdone)
+	go writer(mu, numIterations, &activity, cdone)
 	var i int
 	for i = 0; i < numReaders/2; i++ {
-		go reader(&m, numIterations, &activity, cdone)
+		go reader(mu, numIterations, &activity, cdone)
 	}
-	go writer(&m, numIterations, &activity, cdone)
+	go writer(mu, numIterations, &activity, cdone)
 	for ; i < numReaders; i++ {
-		go reader(&m, numIterations, &activity, cdone)
+		go reader(mu, numIterations, &activity, cdone)
 	}
 	// Wait for the 2 writers and all readers to finish.
 	for i := 0; i < 2+numReaders; i++ {
@@ -115,11 +118,8 @@ func hammerRBMutex(gomaxprocs, numReaders, numIterations int) {
 }
 
 func TestRBMutex(t *testing.T) {
-	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(-1))
-	n := 1000
-	if testing.Short() {
-		n = 5
-	}
+	const n = 1000
+	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(0))
 	hammerRBMutex(1, 1, n)
 	hammerRBMutex(1, 3, n)
 	hammerRBMutex(1, 10, n)
@@ -133,22 +133,25 @@ func TestRBMutex(t *testing.T) {
 }
 
 func benchmarkRBMutex(b *testing.B, localWork, writeRatio int) {
-	var m RBMutex
+	mu := NewRBMutex()
 	b.RunParallel(func(pb *testing.PB) {
 		foo := 0
 		for pb.Next() {
 			foo++
 			if writeRatio > 0 && foo%writeRatio == 0 {
-				m.Lock()
-				//lint:ignore SA2001 critical section is empty in this benchmark
-				m.Unlock()
-			} else {
-				tk := m.RLock()
+				mu.Lock()
 				for i := 0; i != localWork; i += 1 {
 					foo *= 2
 					foo /= 2
 				}
-				m.RUnlock(tk)
+				mu.Unlock()
+			} else {
+				tk := mu.RLock()
+				for i := 0; i != localWork; i += 1 {
+					foo *= 2
+					foo /= 2
+				}
+				mu.RUnlock(tk)
 			}
 		}
 		_ = foo
@@ -159,6 +162,10 @@ func BenchmarkRBMutexReadOnly(b *testing.B) {
 	benchmarkRBMutex(b, 0, -1)
 }
 
+func BenchmarkRBMutexWrite100000(b *testing.B) {
+	benchmarkRBMutex(b, 0, 100000)
+}
+
 func BenchmarkRBMutexWrite10000(b *testing.B) {
 	benchmarkRBMutex(b, 0, 10000)
 }
@@ -167,12 +174,12 @@ func BenchmarkRBMutexWrite1000(b *testing.B) {
 	benchmarkRBMutex(b, 0, 1000)
 }
 
-func BenchmarkRBMutexWrite100(b *testing.B) {
-	benchmarkRBMutex(b, 0, 100)
-}
-
 func BenchmarkRBMutexWorkReadOnly(b *testing.B) {
 	benchmarkRBMutex(b, 100, -1)
+}
+
+func BenchmarkRBMutexWorkWrite100000(b *testing.B) {
+	benchmarkRBMutex(b, 100, 100000)
 }
 
 func BenchmarkRBMutexWorkWrite10000(b *testing.B) {
@@ -183,27 +190,26 @@ func BenchmarkRBMutexWorkWrite1000(b *testing.B) {
 	benchmarkRBMutex(b, 100, 1000)
 }
 
-func BenchmarkRBMutexWorkWrite100(b *testing.B) {
-	benchmarkRBMutex(b, 100, 100)
-}
-
 func benchmarkRWMutex(b *testing.B, localWork, writeRatio int) {
-	var m sync.RWMutex
+	var mu sync.RWMutex
 	b.RunParallel(func(pb *testing.PB) {
 		foo := 0
 		for pb.Next() {
 			foo++
 			if writeRatio > 0 && foo%writeRatio == 0 {
-				m.Lock()
-				//lint:ignore SA2001 critical section is empty in this benchmark
-				m.Unlock()
-			} else {
-				m.RLock()
+				mu.Lock()
 				for i := 0; i != localWork; i += 1 {
 					foo *= 2
 					foo /= 2
 				}
-				m.RUnlock()
+				mu.Unlock()
+			} else {
+				mu.RLock()
+				for i := 0; i != localWork; i += 1 {
+					foo *= 2
+					foo /= 2
+				}
+				mu.RUnlock()
 			}
 		}
 		_ = foo
@@ -214,6 +220,10 @@ func BenchmarkRWMutexReadOnly(b *testing.B) {
 	benchmarkRWMutex(b, 0, -1)
 }
 
+func BenchmarkRWMutexWrite100000(b *testing.B) {
+	benchmarkRWMutex(b, 0, 100000)
+}
+
 func BenchmarkRWMutexWrite10000(b *testing.B) {
 	benchmarkRWMutex(b, 0, 10000)
 }
@@ -222,12 +232,12 @@ func BenchmarkRWMutexWrite1000(b *testing.B) {
 	benchmarkRWMutex(b, 0, 1000)
 }
 
-func BenchmarkRWMutexWrite100(b *testing.B) {
-	benchmarkRWMutex(b, 0, 100)
-}
-
 func BenchmarkRWMutexWorkReadOnly(b *testing.B) {
 	benchmarkRWMutex(b, 100, -1)
+}
+
+func BenchmarkRWMutexWorkWrite100000(b *testing.B) {
+	benchmarkRWMutex(b, 100, 100000)
 }
 
 func BenchmarkRWMutexWorkWrite10000(b *testing.B) {
@@ -236,8 +246,4 @@ func BenchmarkRWMutexWorkWrite10000(b *testing.B) {
 
 func BenchmarkRWMutexWorkWrite1000(b *testing.B) {
 	benchmarkRWMutex(b, 100, 1000)
-}
-
-func BenchmarkRWMutexWorkWrite100(b *testing.B) {
-	benchmarkRWMutex(b, 100, 100)
 }


### PR DESCRIPTION
* The number of reader slots is now calculated dynamically based on the number of cores and `GOMAXPROCS`
* The algorithm is now different from the vanilla BRAVO and unlucky thread-to-slot distribution isn't a problem anymore

Note: this is a breaking change due to the new `NewRBMutex` method.