### PR TITLE
Optimize MapOf integer hash function

### DIFF
--- a/map_test.go
+++ b/map_test.go
@@ -537,12 +537,12 @@ func TestMapResize(t *testing.T) {
 	if stats.Size != numEntries {
 		t.Fatalf("size was too small: %d", stats.Size)
 	}
-	expectedCapacity := int(math.RoundToEven(MapLoadFactor+1)) * stats.TableLen * EntriesPerMapBucket
+	expectedCapacity := int(math.RoundToEven(MapLoadFactor+1)) * stats.RootBuckets * EntriesPerMapBucket
 	if stats.Capacity > expectedCapacity {
 		t.Fatalf("capacity was too large: %d, expected: %d", stats.Capacity, expectedCapacity)
 	}
-	if stats.TableLen <= MinMapTableLen {
-		t.Fatalf("table was too small: %d", stats.TableLen)
+	if stats.RootBuckets <= MinMapTableLen {
+		t.Fatalf("table was too small: %d", stats.RootBuckets)
 	}
 	if stats.TotalGrowths == 0 {
 		t.Fatalf("non-zero total growths expected: %d", stats.TotalGrowths)
@@ -560,12 +560,12 @@ func TestMapResize(t *testing.T) {
 	if stats.Size > 0 {
 		t.Fatalf("zero size was expected: %d", stats.Size)
 	}
-	expectedCapacity = stats.TableLen * EntriesPerMapBucket
+	expectedCapacity = stats.RootBuckets * EntriesPerMapBucket
 	if stats.Capacity != expectedCapacity {
 		t.Fatalf("capacity was too large: %d, expected: %d", stats.Capacity, expectedCapacity)
 	}
-	if stats.TableLen != MinMapTableLen {
-		t.Fatalf("table was too large: %d", stats.TableLen)
+	if stats.RootBuckets != MinMapTableLen {
+		t.Fatalf("table was too large: %d", stats.RootBuckets)
 	}
 	if stats.TotalShrinks == 0 {
 		t.Fatalf("non-zero total shrinks expected: %d", stats.TotalShrinks)

--- a/mapof_test.go
+++ b/mapof_test.go
@@ -685,12 +685,12 @@ func TestMapOfResize(t *testing.T) {
 	if stats.Size != numEntries {
 		t.Fatalf("size was too small: %d", stats.Size)
 	}
-	expectedCapacity := int(math.RoundToEven(MapLoadFactor+1)) * stats.TableLen * EntriesPerMapBucket
+	expectedCapacity := int(math.RoundToEven(MapLoadFactor+1)) * stats.RootBuckets * EntriesPerMapBucket
 	if stats.Capacity > expectedCapacity {
 		t.Fatalf("capacity was too large: %d, expected: %d", stats.Capacity, expectedCapacity)
 	}
-	if stats.TableLen <= MinMapTableLen {
-		t.Fatalf("table was too small: %d", stats.TableLen)
+	if stats.RootBuckets <= MinMapTableLen {
+		t.Fatalf("table was too small: %d", stats.RootBuckets)
 	}
 	if stats.TotalGrowths == 0 {
 		t.Fatalf("non-zero total growths expected: %d", stats.TotalGrowths)
@@ -708,12 +708,12 @@ func TestMapOfResize(t *testing.T) {
 	if stats.Size > 0 {
 		t.Fatalf("zero size was expected: %d", stats.Size)
 	}
-	expectedCapacity = stats.TableLen * EntriesPerMapBucket
+	expectedCapacity = stats.RootBuckets * EntriesPerMapBucket
 	if stats.Capacity != expectedCapacity {
 		t.Fatalf("capacity was too large: %d, expected: %d", stats.Capacity, expectedCapacity)
 	}
-	if stats.TableLen != MinMapTableLen {
-		t.Fatalf("table was too large: %d", stats.TableLen)
+	if stats.RootBuckets != MinMapTableLen {
+		t.Fatalf("table was too large: %d", stats.RootBuckets)
 	}
 	if stats.TotalShrinks == 0 {
 		t.Fatalf("non-zero total shrinks expected: %d", stats.TotalShrinks)

--- a/util.go
+++ b/util.go
@@ -3,6 +3,7 @@ package xsync
 import (
 	"hash/maphash"
 	"runtime"
+	"unsafe"
 	_ "unsafe"
 )
 
@@ -47,6 +48,18 @@ func parallelism() uint32 {
 	return numCores
 }
 
+// inthash64 is a hash function based on murmurhash3 64-bit finalizer.
+//
+//lint:ignore U1000 used in MapOf
+func hashUint64(seed maphash.Seed, v uint64) uint64 {
+	nseed := *(*uint64)(unsafe.Pointer(&seed))
+	return uint64(memhash64(unsafe.Pointer(&v), uintptr(nseed)))
+}
+
 //go:noescape
 //go:linkname fastrand runtime.fastrand
 func fastrand() uint32
+
+//go:noescape
+//go:linkname memhash64 runtime.memhash64
+func memhash64(p unsafe.Pointer, h uintptr) uintptr


### PR DESCRIPTION
Benchmarks for `MapOf[int, int]` with 64 keys

Before:
```
BenchmarkIntegerMapOf_WarmUp/reads=100%-8         	170225940	         7.107 ns/op	       0 B/op	       0 allocs/op
BenchmarkIntegerMapOf_WarmUp/reads=99%-8          	147592124	         8.331 ns/op	       0 B/op	       0 allocs/op
BenchmarkIntegerMapOf_WarmUp/reads=90%-reads-8    	100000000	        11.09 ns/op	       1 B/op	       0 allocs/op
BenchmarkIntegerMapOf_WarmUp/reads=75%-reads-8    	78332457	        16.03 ns/op	       4 B/op	       0 allocs/op
```

After:
```
BenchmarkIntegerMapOf_WarmUp/reads=100%-8         	208831473	         5.325 ns/op	       0 B/op	       0 allocs/op
BenchmarkIntegerMapOf_WarmUp/reads=99%-8          	180287820	         6.516 ns/op	       0 B/op	       0 allocs/op
BenchmarkIntegerMapOf_WarmUp/reads=90%-reads-8    	127232131	         9.812 ns/op	       1 B/op	       0 allocs/op
BenchmarkIntegerMapOf_WarmUp/reads=75%-reads-8    	84348110	        13.95 ns/op	       4 B/op	       0 allocs/op
```