### PR TITLE
New MapOf design

### DIFF
--- a/export_mapof_test.go
+++ b/export_mapof_test.go
@@ -3,6 +3,10 @@
 
 package xsync
 
+type (
+	BucketOfPadded = bucketOfPadded
+)
+
 func CollectMapOfStats[K comparable, V any](m *MapOf[K, V]) MapStats {
 	return MapStats{m.stats()}
 }

--- a/export_test.go
+++ b/export_test.go
@@ -46,3 +46,7 @@ func EnableAssertions() {
 func DisableAssertions() {
 	assertionsEnabled = false
 }
+
+func Fastrand() uint32 {
+	return fastrand()
+}

--- a/map_test.go
+++ b/map_test.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	// number of entries to use in benchmarks
-	benchmarkNumEntries = 1_000_000
+	benchmarkNumEntries = 1_000
 	// key prefix used in benchmarks
 	benchmarkKeyPrefix = "what_a_looooooooooooooooooooooong_key_prefix_"
 )
@@ -122,7 +122,7 @@ func TestMap_EmptyStringKey(t *testing.T) {
 	m.Store("", "foobar")
 	v, ok := m.Load("")
 	if !ok {
-		t.Error("value was expected")
+		t.Fatal("value was expected")
 	}
 	if vs, ok := v.(string); ok && vs != "foobar" {
 		t.Fatalf("value does not match: %v", v)
@@ -134,7 +134,7 @@ func TestMapStore_NilValue(t *testing.T) {
 	m.Store("foo", nil)
 	v, ok := m.Load("foo")
 	if !ok {
-		t.Error("nil value was expected")
+		t.Fatal("nil value was expected")
 	}
 	if v != nil {
 		t.Fatalf("value was not nil: %v", v)
@@ -146,7 +146,7 @@ func TestMapLoadOrStore_NilValue(t *testing.T) {
 	m.LoadOrStore("foo", nil)
 	v, loaded := m.LoadOrStore("foo", nil)
 	if !loaded {
-		t.Error("nil value was expected")
+		t.Fatal("nil value was expected")
 	}
 	if v != nil {
 		t.Fatalf("value was not nil: %v", v)
@@ -159,7 +159,7 @@ func TestMapLoadOrStore_NonNilValue(t *testing.T) {
 	newv := &foo{}
 	v, loaded := m.LoadOrStore("foo", newv)
 	if loaded {
-		t.Error("no value was expected")
+		t.Fatal("no value was expected")
 	}
 	if v != newv {
 		t.Fatalf("value does not match: %v", v)
@@ -167,7 +167,7 @@ func TestMapLoadOrStore_NonNilValue(t *testing.T) {
 	newv2 := &foo{}
 	v, loaded = m.LoadOrStore("foo", newv2)
 	if !loaded {
-		t.Error("value was expected")
+		t.Fatal("value was expected")
 	}
 	if v != newv {
 		t.Fatalf("value does not match: %v", v)
@@ -179,14 +179,14 @@ func TestMapLoadAndStore_NilValue(t *testing.T) {
 	m.LoadAndStore("foo", nil)
 	v, loaded := m.LoadAndStore("foo", nil)
 	if !loaded {
-		t.Error("nil value was expected")
+		t.Fatal("nil value was expected")
 	}
 	if v != nil {
 		t.Fatalf("value was not nil: %v", v)
 	}
 	v, loaded = m.Load("foo")
 	if !loaded {
-		t.Error("nil value was expected")
+		t.Fatal("nil value was expected")
 	}
 	if v != nil {
 		t.Fatalf("value was not nil: %v", v)
@@ -199,7 +199,7 @@ func TestMapLoadAndStore_NonNilValue(t *testing.T) {
 	v1 := &foo{}
 	v, loaded := m.LoadAndStore("foo", v1)
 	if loaded {
-		t.Error("no value was expected")
+		t.Fatal("no value was expected")
 	}
 	if v != v1 {
 		t.Fatalf("value does not match: %v", v)
@@ -207,14 +207,14 @@ func TestMapLoadAndStore_NonNilValue(t *testing.T) {
 	v2 := 2
 	v, loaded = m.LoadAndStore("foo", v2)
 	if !loaded {
-		t.Error("value was expected")
+		t.Fatal("value was expected")
 	}
 	if v != v1 {
 		t.Fatalf("value does not match: %v", v)
 	}
 	v, loaded = m.Load("foo")
 	if !loaded {
-		t.Error("value was expected")
+		t.Fatal("value was expected")
 	}
 	if v != v2 {
 		t.Fatalf("value does not match: %v", v)
@@ -1083,13 +1083,12 @@ func benchmarkMap(
 ) {
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
-		r := rand.New(rand.NewSource(time.Now().UnixNano()))
 		// convert percent to permille to support 99% case
 		storeThreshold := 10 * readPercentage
 		deleteThreshold := 10*readPercentage + ((1000 - 10*readPercentage) / 2)
 		for pb.Next() {
-			op := r.Intn(1000)
-			i := r.Intn(benchmarkNumEntries)
+			op := int(Fastrand() % 1000)
+			i := int(Fastrand() % benchmarkNumEntries)
 			if op >= deleteThreshold {
 				deleteFn(benchmarkKeys[i])
 			} else if op >= storeThreshold {

--- a/util.go
+++ b/util.go
@@ -3,7 +3,6 @@ package xsync
 import (
 	"hash/maphash"
 	"runtime"
-	"unsafe"
 	_ "unsafe"
 )
 
@@ -17,14 +16,6 @@ const (
 	// improvement on NUMA machines.
 	cacheLineSize = 64
 )
-
-// hashString calculates a hash of s with the given seed.
-func hashString(seed maphash.Seed, s string) uint64 {
-	var h maphash.Hash
-	h.SetSeed(seed)
-	h.WriteString(s)
-	return h.Sum64()
-}
 
 // nextPowOf2 computes the next highest power of 2 of 32-bit v.
 // Source: https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
@@ -48,18 +39,14 @@ func parallelism() uint32 {
 	return numCores
 }
 
-// hashUint64 calculates a hash of v with the given seed.
-//
-//lint:ignore U1000 used in MapOf
-func hashUint64(seed maphash.Seed, v uint64) uint64 {
-	nseed := *(*uint64)(unsafe.Pointer(&seed))
-	return uint64(memhash64(unsafe.Pointer(&v), uintptr(nseed)))
+// hashString calculates a hash of s with the given seed.
+func hashString(seed maphash.Seed, s string) uint64 {
+	var h maphash.Hash
+	h.SetSeed(seed)
+	h.WriteString(s)
+	return h.Sum64()
 }
 
 //go:noescape
 //go:linkname fastrand runtime.fastrand
 func fastrand() uint32
-
-//go:noescape
-//go:linkname memhash64 runtime.memhash64
-func memhash64(p unsafe.Pointer, h uintptr) uintptr

--- a/util_mapof.go
+++ b/util_mapof.go
@@ -1,0 +1,22 @@
+//go:build go1.18
+// +build go1.18
+
+package xsync
+
+import (
+	"hash/maphash"
+	"unsafe"
+)
+
+// hashUint64 calculates a hash of v with the given seed.
+//
+//lint:ignore U1000 used in MapOf
+func hashUint64[K IntegerConstraint](seed maphash.Seed, k K) uint64 {
+	n := uint64(k)
+	// Java's Long standard hash function.
+	n = n ^ (n >> 32)
+	nseed := *(*uint64)(unsafe.Pointer(&seed))
+	// Modified boost's hash_combine.
+	nseed ^= n + 0x9e3779b97f4a7c15 + (nseed << 12) + (nseed >> 4)
+	return nseed
+}


### PR DESCRIPTION
* `MapOf`'s design is now quite different from the `Map`'s one. `MapOf` uses immutable entry structs, so there are less objects allocated on the heap and, thus, less GC pressure. There is also no need to store hash tops - the whole hash code is now stored in buckets. `sync.Mutex` is used instead of a in-house spin lock.
* Hand-made hash function is now used for integers. It's of mediocre quality, but the compiler inlines it more happily than `memhash64`.

Benchmarks for `MapOf[int, int]` with 1K entries. The change is very noticeable on such small maps and fixed size keys.

Before:
```bash
$ go test -run=^$ -bench IntegerMapOf_WarmUp
goos: linux
goarch: amd64
pkg: github.com/puzpuzpuz/xsync/v2
cpu: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
BenchmarkIntegerMapOf_WarmUp/reads=100%-8         	293524755	         4.124 ns/op
BenchmarkIntegerMapOf_WarmUp/reads=99%-8          	236453667	         5.025 ns/op
BenchmarkIntegerMapOf_WarmUp/reads=90%-reads-8    	168052021	         7.140 ns/op
BenchmarkIntegerMapOf_WarmUp/reads=75%-reads-8    	115658304	        10.30 ns/op
PASS
ok  	github.com/puzpuzpuz/xsync/v2	7.254s
```

After:
```bash
$ go test -run=^$ -bench IntegerMapOf_WarmUp
goos: linux
goarch: amd64
pkg: github.com/puzpuzpuz/xsync/v2
cpu: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
BenchmarkIntegerMapOf_WarmUp/reads=100%-8         	452138901	         2.735 ns/op
BenchmarkIntegerMapOf_WarmUp/reads=99%-8          	316428153	         3.561 ns/op
BenchmarkIntegerMapOf_WarmUp/reads=90%-reads-8    	246066069	         5.068 ns/op
BenchmarkIntegerMapOf_WarmUp/reads=75%-reads-8    	167377144	         7.001 ns/op
PASS
ok  	github.com/puzpuzpuz/xsync/v2	6.661s
```