### PR TITLE
add counter.AddAndLoad

### DIFF
--- a/counter_test.go
+++ b/counter_test.go
@@ -38,6 +38,17 @@ func TestCounterAdd(t *testing.T) {
 	}
 }
 
+func TestCounterAddAndLoad(t *testing.T) {
+	c := NewCounter()
+	var v int64
+	for i := 0; i < 100; i++ {
+		if v != int64(i*42) {
+			t.Fatalf("got %v, want %d", v, i*42)
+		}
+		v = c.AddAndLoad(42)
+	}
+}
+
 func TestCounterReset(t *testing.T) {
 	c := NewCounter()
 	c.Add(42)


### PR DESCRIPTION
Introduces a new method to counter: `AddAndLoad(delta) int64`.
AddAndLoad fills a support gap where end users need to handle
synchronicity themselves by locking over an add,value pair of operations.