### PR TITLE
Add `allocsPerTest` test case for `mapof.Load`

### DIFF
--- a/map_test.go
+++ b/map_test.go
@@ -1320,3 +1320,22 @@ func BenchmarkMapRangeStandard(b *testing.B) {
 		}
 	})
 }
+
+func TestMapAllocsPerRun(t *testing.T) {
+	tt := func() string {
+		tmp := []byte("foo")
+		return string(tmp)
+	}
+
+	m := NewMapPresized(100_000)
+	m.Store(tt(), nil)
+	allocs := testing.AllocsPerRun(100, func() {
+		_, ok := m.Load(tt())
+		if !ok {
+			t.Fatal("value was expected, but is missing", ok)
+		}
+	})
+	if allocs != 0.0 {
+		t.Fatalf("got unexpected number of allocs: %f", allocs)
+	}
+}

--- a/mapof_test.go
+++ b/mapof_test.go
@@ -142,6 +142,25 @@ func TestMapOfLoadAndStore_NonNilValue(t *testing.T) {
 	}
 }
 
+func TestMapOfAllocsPerRun(t *testing.T) {
+	tt := func() string {
+		tmp := []byte("foo")
+		return string(tmp)
+	}
+
+	m := NewMapOfPresized[string, *struct{}](100_000)
+	m.Store(tt(), nil)
+	allocs := testing.AllocsPerRun(100, func() {
+		_, ok := m.Load(tt())
+		if !ok {
+			t.Fatal("value was expected, but is missing", ok)
+		}
+	})
+	if allocs != 1.0 {
+		t.Fatalf("got unexpected number of allocs: %f", allocs)
+	}
+}
+
 func TestMapOfRange(t *testing.T) {
 	const numEntries = 1000
 	m := NewMapOf[string, int]()


### PR DESCRIPTION
For #126

This doesn't fix the issue, but it's a reproduction.

I find the allocsPerTest a nice way of preventing future regressions, so I'm hoping this will be useful in the repo generally - irrespectively whether the issue gets fixed or not.