### PR TITLE
Introduce Map/MapOf configs and grow-only option

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -73,9 +73,9 @@ func CollectMapOfStats[K comparable, V any](m *MapOf[K, V]) MapStats {
 	return MapStats{m.stats()}
 }
 
-func NewMapOfPresizedWithHasher[K comparable, V any](
+func NewMapOfWithHasher[K comparable, V any](
 	hasher func(K, uint64) uint64,
-	sizeHint int,
+	options ...func(*MapConfig),
 ) *MapOf[K, V] {
-	return newMapOfPresized[K, V](hasher, sizeHint)
+	return newMapOf[K, V](hasher, options...)
 }


### PR DESCRIPTION
Adds options support to the `NewMap`/`NewMapOf` functions. A `MapOf` can now be created like this:
```go
m := xsync.NewMapOf(WithPresize(100))
```

Also, adds `WithGrowOnly` option. It configures new Map/MapOf instance to be grow-only. This means that the underlying hash table grows in capacity when new keys are added, but does not shrink when keys are deleted. The only exception to this rule is the Clear method which shrinks the hash table back to the initial capacity.

Grow-only maps are more efficient in the case of oscillating map size, i.e. when the map frequently grows and then shrinks in size.