### PR TITLE
Expose Map/MapOf statistics

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -13,14 +13,6 @@ type (
 	BucketOfPadded = bucketOfPadded
 )
 
-type MapStats struct {
-	mapStats
-}
-
-func CollectMapStats(m *Map) MapStats {
-	return MapStats{m.stats()}
-}
-
 func LockBucket(mu *uint64) {
 	lockBucket(mu)
 }
@@ -67,10 +59,6 @@ func HashString(s string, seed uint64) uint64 {
 
 func MakeHasher[T comparable]() func(T, uint64) uint64 {
 	return makeHasher[T]()
-}
-
-func CollectMapOfStats[K comparable, V any](m *MapOf[K, V]) MapStats {
-	return MapStats{m.stats()}
 }
 
 func NewMapOfWithHasher[K comparable, V any](

--- a/mapof.go
+++ b/mapof.go
@@ -639,9 +639,11 @@ func shiftHash(h uint64) uint64 {
 	return h
 }
 
-// O(N) operation; use for debug purposes only
-func (m *MapOf[K, V]) stats() mapStats {
-	stats := mapStats{
+// Stats returns statistics for the MapOf. Just like other map
+// methods, this one is thread-safe. Yet it's an O(N) operation,
+// so it should be used only for diagnostics or debugging purposes.
+func (m *MapOf[K, V]) Stats() MapStats {
+	stats := MapStats{
 		TotalGrowths: atomic.LoadInt64(&m.totalGrowths),
 		TotalShrinks: atomic.LoadInt64(&m.totalShrinks),
 		MinEntries:   math.MaxInt32,
@@ -670,7 +672,7 @@ func (m *MapOf[K, V]) stats() mapStats {
 			if b.next == nil {
 				break
 			}
-			b = (*bucketOfPadded)(b.next)
+			b = (*bucketOfPadded)(atomic.LoadPointer(&b.next))
 			stats.TotalBuckets++
 		}
 		if nentries < stats.MinEntries {


### PR DESCRIPTION
Map/MapOf statistics are available via `m.Stats()`. They may be used for diagnostic purposes.