### PR TITLE
Add NewMapOfWithHasher function

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -75,13 +75,6 @@ func HashString(s string, seed uint64) uint64 {
 	return hashString(s, seed)
 }
 
-func MakeHasher[T comparable]() func(T, uint64) uint64 {
-	return makeHasher[T]()
-}
-
-func NewMapOfWithHasher[K comparable, V any](
-	hasher func(K, uint64) uint64,
-	options ...func(*MapConfig),
-) *MapOf[K, V] {
-	return newMapOf[K, V](hasher, options...)
+func DefaultHasher[T comparable]() func(T, uint64) uint64 {
+	return defaultHasher[T]()
 }

--- a/mapof.go
+++ b/mapof.go
@@ -84,21 +84,14 @@ type entryOf[K comparable, V any] struct {
 // NewMapOf creates a new MapOf instance configured with the given
 // options.
 func NewMapOf[K comparable, V any](options ...func(*MapConfig)) *MapOf[K, V] {
-	return newMapOf[K, V](makeHasher[K](), options...)
+	return NewMapOfWithHasher[K, V](defaultHasher[K](), options...)
 }
 
-// NewMapOfPresized creates a new MapOf instance with capacity enough
-// to hold sizeHint entries. The capacity is treated as the minimal capacity
-// meaning that the underlying hash table will never shrink to
-// a smaller capacity. If sizeHint is zero or negative, the value
-// is ignored.
-//
-// Deprecated: use NewMapOf in combination with WithPresize.
-func NewMapOfPresized[K comparable, V any](sizeHint int) *MapOf[K, V] {
-	return NewMapOf[K, V](WithPresize(sizeHint))
-}
-
-func newMapOf[K comparable, V any](
+// NewMapOf creates a new MapOf instance configured with the given
+// hasher and options. The hash function is used instead of
+// the built-in hash function configured when a map is created
+// with the NewMapOf function.
+func NewMapOfWithHasher[K comparable, V any](
 	hasher func(K, uint64) uint64,
 	options ...func(*MapConfig),
 ) *MapOf[K, V] {
@@ -123,6 +116,17 @@ func newMapOf[K comparable, V any](
 	m.growOnly = c.growOnly
 	atomic.StorePointer(&m.table, unsafe.Pointer(table))
 	return m
+}
+
+// NewMapOfPresized creates a new MapOf instance with capacity enough
+// to hold sizeHint entries. The capacity is treated as the minimal capacity
+// meaning that the underlying hash table will never shrink to
+// a smaller capacity. If sizeHint is zero or negative, the value
+// is ignored.
+//
+// Deprecated: use NewMapOf in combination with WithPresize.
+func NewMapOfPresized[K comparable, V any](sizeHint int) *MapOf[K, V] {
+	return NewMapOf[K, V](WithPresize(sizeHint))
 }
 
 func newMapOfTable[K comparable, V any](minTableLen int) *mapOfTable[K, V] {

--- a/util_hash.go
+++ b/util_hash.go
@@ -33,10 +33,10 @@ func hashString(s string, seed uint64) uint64 {
 //go:linkname runtime_memhash runtime.memhash
 func runtime_memhash(p unsafe.Pointer, h, s uintptr) uintptr
 
-// makeHasher creates a fast hash function for the given comparable type.
+// defaultHasher creates a fast hash function for the given comparable type.
 // The only limitation is that the type should not contain interfaces inside
 // based on runtime.typehash.
-func makeHasher[T comparable]() func(T, uint64) uint64 {
+func defaultHasher[T comparable]() func(T, uint64) uint64 {
 	var zero T
 
 	if reflect.TypeOf(&zero).Elem().Kind() == reflect.Interface {

--- a/util_hash_test.go
+++ b/util_hash_test.go
@@ -20,8 +20,8 @@ func TestMakeHashFunc(t *testing.T) {
 
 	seed := MakeSeed()
 
-	hashString := MakeHasher[string]()
-	hashUser := MakeHasher[User]()
+	hashString := DefaultHasher[string]()
+	hashUser := DefaultHasher[User]()
 
 	hashUserMap := makeMapHasher[User]()
 
@@ -186,7 +186,7 @@ func BenchmarkMakeHashFunc(b *testing.B) {
 }
 
 func doBenchmarkMakeHashFunc[T comparable](b *testing.B, val T) {
-	hash := MakeHasher[T]()
+	hash := DefaultHasher[T]()
 	hashNativeMap := makeMapHasher[T]()
 	seed := MakeSeed()
 


### PR DESCRIPTION
Adds `NewMapOfWithHasher` function to support custom hash functions:
```go
m := NewMapOfWithHasher[int, int](func(i int, _ uint64) uint64 {
	// Murmur3 finalizer. No DDOS protection as it does not support seed.
	h := uint64(i)
	h = (h ^ (h >> 33)) * 0xff51afd7ed558ccd
	h = (h ^ (h >> 33)) * 0xc4ceb9fe1a85ec53
	return h ^ (h >> 33)
})
```

Some custom hash functions may be faster than the built-in function if the lack of DDOS protection is fine.

Murmur3 finalizer:
```bash
BenchmarkMapOfInt_Murmur3Finalizer_WarmUp/reads=100%-8         	525864650	         2.240 ns/op	 446360938 ops/s	       0 B/op	       0 allocs/op
BenchmarkMapOfInt_Murmur3Finalizer_WarmUp/reads=99%-8          	383333918	         3.127 ns/op	 319827294 ops/s	       0 B/op	       0 allocs/op
BenchmarkMapOfInt_Murmur3Finalizer_WarmUp/reads=90%-8          	267635385	         4.535 ns/op	 220506863 ops/s	       0 B/op	       0 allocs/op
BenchmarkMapOfInt_Murmur3Finalizer_WarmUp/reads=75%-8          	181292007	         6.448 ns/op	 155092697 ops/s	       2 B/op	       0 allocs/op
```

Built-in hash function:
```bash
BenchmarkMapOfInt_WarmUp/reads=100%-8         	431097415	         2.858 ns/op	 349837551 ops/s	       0 B/op	       0 allocs/op
BenchmarkMapOfInt_WarmUp/reads=99%-8          	307244330	         3.951 ns/op	 253072903 ops/s	       0 B/op	       0 allocs/op
BenchmarkMapOfInt_WarmUp/reads=90%-8          	226392990	         5.306 ns/op	 188477583 ops/s	       0 B/op	       0 allocs/op
BenchmarkMapOfInt_WarmUp/reads=75%-8          	159236962	         7.513 ns/op	 133108546 ops/s	       2 B/op	       0 allocs/op
```