### PR TITLE
RFC: MapOf: custom comparators and better custom hashers

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -70,11 +70,3 @@ func NextPowOf2(v uint32) uint32 {
 func MakeSeed() uint64 {
 	return makeSeed()
 }
-
-func HashString(s string, seed uint64) uint64 {
-	return hashString(s, seed)
-}
-
-func DefaultHasher[T comparable]() func(T, uint64) uint64 {
-	return defaultHasher[T]()
-}

--- a/util_hash.go
+++ b/util_hash.go
@@ -26,7 +26,18 @@ func hashString(s string, seed uint64) uint64 {
 		return seed
 	}
 	strh := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	return uint64(runtime_memhash(unsafe.Pointer(strh.Data), uintptr(seed), uintptr(strh.Len)))
+	return runtime_memhash64(unsafe.Pointer(strh.Data), seed, uintptr(strh.Len))
+}
+
+// same as runtime_memhash, but always returns a uint64
+func runtime_memhash64(p unsafe.Pointer, seed uint64, length uintptr) uint64 {
+	if unsafe.Sizeof(uintptr(0)) == 8 {
+		return uint64(runtime_memhash(p, uintptr(seed), length))
+	}
+
+	lo := runtime_memhash(p, uintptr(seed), length)
+	hi := runtime_memhash(p, uintptr(seed>>32), length)
+	return uint64(hi)<<32 | uint64(lo)
 }
 
 //go:noescape

--- a/util_hash_test.go
+++ b/util_hash_test.go
@@ -20,8 +20,8 @@ func TestMakeHashFunc(t *testing.T) {
 
 	seed := MakeSeed()
 
-	hashString := DefaultHasher[string]()
-	hashUser := DefaultHasher[User]()
+	hashString := Hasher[string]()
+	hashUser := Hasher[User]()
 
 	hashUserMap := makeMapHasher[User]()
 
@@ -186,7 +186,7 @@ func BenchmarkMakeHashFunc(b *testing.B) {
 }
 
 func doBenchmarkMakeHashFunc[T comparable](b *testing.B, val T) {
-	hash := DefaultHasher[T]()
+	hash := Hasher[T]()
 	hashNativeMap := makeMapHasher[T]()
 	seed := MakeSeed()
 


### PR DESCRIPTION
This PR consists of two parts, one of which is probably less controversial and the other one is likely extremely controversial (hence the RFC mark).

I'm unfamiliar with Go and this ecosystem feels very alien to me, so please excuse me if any of this makes no sense.

1. Add support for custom comparators to `MapOf` in addition to custom hashers.
   As it happens, `xsync.MapOf` appears to be the best general-purpose hash map
   implementation that does not just defer to the built-in Go map. Thus, it has
   potential to support fully arbitrary (non-comparable) types, such as slices.
   Thus, make this potential a reality by adding support for custom comparators
   in addition to custom hashers.
    - **MapOf: allow a custom comparator in addition to a custom hasher**

2. Export some functions to simplify creating custom hashers.  
   Basically, this just re-exports xsync's wrappers over Go `runtime.*` hashers
   that are (ab)used internally. This is likely controversial, but I don't see
   a better idea. If/when Go finally decides to tighten the screws and strictly
   prohibit anyone from calling into `runtime.*`, both xsync's internal wrappers
   and exported wrappers can just be rewritten all at once, saving other projects
   the pain.
    - **util: define/use a `runtime_memhash64` similar to `runtime_typehash64`**
    - **util: export functions for creating custom hashers**
