### PR TITLE
Rename and deprecate `*Of` types

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Covered with tests following the approach described [here](https://puzpuzpuz.dev
 
 Benchmark results may be found [here](BENCHMARKS.md). I'd like to thank [@felixge](https://github.com/felixge) who kindly ran the benchmarks on a beefy multicore machine.
 
-Also, a non-scientific, unfair benchmark comparing Java's [j.u.c.ConcurrentHashMap](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/concurrent/ConcurrentHashMap.html) and `xsync.MapOf` is available [here](https://puzpuzpuz.dev/concurrent-map-in-go-vs-java-yet-another-meaningless-benchmark).
+Also, a non-scientific, unfair benchmark comparing Java's [j.u.c.ConcurrentHashMap](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/concurrent/ConcurrentHashMap.html) and `xsync.Map` is available [here](https://puzpuzpuz.dev/concurrent-map-in-go-vs-java-yet-another-meaningless-benchmark).
 
 ## Usage
 
@@ -24,7 +24,7 @@ import (
 )
 ```
 
-*Note for pre-v4 users*: the main change between v3 and v4 is removal of non-generic data structures and some improvements in `MapOf` API. While the API has some breaking changes, the migration should be trivial.
+*Note for pre-v4 users*: the main change between v3 and v4 is removal of non-generic data structures and some improvements in `Map` API. While the API has some breaking changes, the migration should be trivial.
 
 ### Counter
 
@@ -41,38 +41,38 @@ v := c.Value()
 
 Works better in comparison with a single atomically updated `int64` counter in high contention scenarios.
 
-### MapOf
+### Map
 
-A `MapOf` is like a concurrent hash table-based map. It follows the interface of `sync.Map` with a number of valuable extensions like `Compute` or `Size`.
+A `Map` is like a concurrent hash table-based map. It follows the interface of `sync.Map` with a number of valuable extensions like `Compute` or `Size`.
 
 ```go
-m := xsync.NewMapOf[string, string]()
+m := xsync.NewMap[string, string]()
 m.Store("foo", "bar")
 v, ok := m.Load("foo")
 s := m.Size()
 ```
 
-`MapOf` uses a modified version of Cache-Line Hash Table (CLHT) data structure: https://github.com/LPD-EPFL/CLHT
+`Map` uses a modified version of Cache-Line Hash Table (CLHT) data structure: https://github.com/LPD-EPFL/CLHT
 
-CLHT is built around the idea of organizing the hash table in cache-line-sized buckets, so that on all modern CPUs update operations complete with minimal cache-line transfer. Also, `Get` operations are obstruction-free and involve no writes to shared memory, hence no mutexes or any other sort of locks. Due to this design, in all considered scenarios `MapOf` outperforms `sync.Map`.
+CLHT is built around the idea of organizing the hash table in cache-line-sized buckets, so that on all modern CPUs update operations complete with minimal cache-line transfer. Also, `Get` operations are obstruction-free and involve no writes to shared memory, hence no mutexes or any other sort of locks. Due to this design, in all considered scenarios `Map` outperforms `sync.Map`.
 
-Apart from CLHT, `MapOf` borrows ideas from Java's `j.u.c.ConcurrentHashMap` (immutable K/V pair structs instead of atomic snapshots) and C++'s `absl::flat_hash_map` (meta memory and SWAR-based lookups).
+Apart from CLHT, `Map` borrows ideas from Java's `j.u.c.ConcurrentHashMap` (immutable K/V pair structs instead of atomic snapshots) and C++'s `absl::flat_hash_map` (meta memory and SWAR-based lookups).
 
-Besides the `Range` method available for map iteration, there is also `ToPlainMapOf` utility function to convert a `MapOf` to a built-in Go's `map`:
+Besides the `Range` method available for map iteration, there is also `ToPlainMap` utility function to convert a `Map` to a built-in Go's `map`:
 ```go
-m := xsync.NewMapOf[int, int]()
+m := xsync.NewMap[int, int]()
 m.Store(42, 42)
-pm := xsync.ToPlainMapOf(m)
+pm := xsync.ToPlainMap(m)
 ```
 
-Finally, `MapOf` uses the built-in Golang's hash function which has DDOS protection. It uses `maphash.Comparable` as the default hash function. This means that each map instance gets its own seed number and the hash function uses that seed for hash code calculation.
+Finally, `Map` uses the built-in Golang's hash function which has DDOS protection. It uses `maphash.Comparable` as the default hash function. This means that each map instance gets its own seed number and the hash function uses that seed for hash code calculation.
 
-### SPSCQueueOf
+### SPSCQueue
 
-A `SPSCQueueOf` is a bounded single-producer single-consumer concurrent queue. This means that not more than a single goroutine must be publishing items to the queue while not more than a single goroutine must be consuming those items.
+A `SPSCQueue` is a bounded single-producer single-consumer concurrent queue. This means that not more than a single goroutine must be publishing items to the queue while not more than a single goroutine must be consuming those items.
 
 ```go
-q := xsync.NewSPSCQueueOf[string](1024)
+q := xsync.NewSPSCQueue[string](1024)
 // producer inserts an item into the queue
 // optimistic insertion attempt; doesn't block
 inserted := q.TryEnqueue("bar")
@@ -85,12 +85,12 @@ The queue is based on the data structure from this [article](https://rigtorp.se/
 
 Make sure to implement proper back-off strategy to handle failed optimistic operation attempts. The most basic back-off would be calling `runtime.Gosched()`.
 
-### MPMCQueueOf
+### MPMCQueue
 
-A `MPMCQueueOf` is a bounded multi-producer multi-consumer concurrent queue.
+A `MPMCQueue` is a bounded multi-producer multi-consumer concurrent queue.
 
 ```go
-q := xsync.NewMPMCQueueOf[string](1024)
+q := xsync.NewMPMCQueue[string](1024)
 // producer optimistically inserts an item into the queue
 // optimistic insertion attempt; doesn't block
 inserted := q.TryEnqueue("bar")
@@ -103,7 +103,7 @@ The queue is based on the algorithm from the [MPMCQueue](https://github.com/rigt
 
 The idea of the algorithm is to allow parallelism for concurrent producers and consumers by introducing the notion of tickets, i.e. values of two counters, one per producers/consumers. An atomic increment of one of those counters is the only noticeable contention point in queue operations. The rest of the operation avoids contention on writes thanks to the turn-based read/write access for each of the queue items.
 
-In essence, `MPMCQueueOf` is a specialized queue for scenarios where there are multiple concurrent producers and consumers of a single queue running on a large multicore machine.
+In essence, `MPMCQueue` is a specialized queue for scenarios where there are multiple concurrent producers and consumers of a single queue running on a large multicore machine.
 
 To get the optimal performance, you may want to set the queue size to be large enough, say, an order of magnitude greater than the number of producers/consumers, to allow producers and consumers to progress with their queue operations in parallel most of the time.
 

--- a/example_test.go
+++ b/example_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func ExampleMapOf_Compute() {
-	counts := xsync.NewMapOf[int, int]()
+	counts := xsync.NewMap[int, int]()
 
 	// Store a new value.
 	v, ok := counts.Compute(42, func(oldValue int, loaded bool) (newValue int, delete bool) {

--- a/export_test.go
+++ b/export_test.go
@@ -1,15 +1,15 @@
 package xsync
 
 const (
-	EntriesPerMapOfBucket   = entriesPerMapOfBucket
+	EntriesPerMapOfBucket   = entriesPerMapBucket
 	MapLoadFactor           = mapLoadFactor
 	DefaultMinMapTableLen   = defaultMinMapTableLen
-	DefaultMinMapOfTableCap = defaultMinMapTableLen * entriesPerMapOfBucket
+	DefaultMinMapOfTableCap = defaultMinMapTableLen * entriesPerMapBucket
 	MaxMapCounterLen        = maxMapCounterLen
 )
 
 type (
-	BucketOfPadded = bucketOfPadded
+	BucketOfPadded = bucketPadded
 )
 
 func EnableAssertions() {

--- a/export_test.go
+++ b/export_test.go
@@ -1,15 +1,15 @@
 package xsync
 
 const (
-	EntriesPerMapOfBucket   = entriesPerMapBucket
-	MapLoadFactor           = mapLoadFactor
-	DefaultMinMapTableLen   = defaultMinMapTableLen
-	DefaultMinMapOfTableCap = defaultMinMapTableLen * entriesPerMapBucket
-	MaxMapCounterLen        = maxMapCounterLen
+	EntriesPerMapBucket   = entriesPerMapBucket
+	MapLoadFactor         = mapLoadFactor
+	DefaultMinMapTableLen = defaultMinMapTableLen
+	DefaultMinMapTableCap = defaultMinMapTableLen * entriesPerMapBucket
+	MaxMapCounterLen      = maxMapCounterLen
 )
 
 type (
-	BucketOfPadded = bucketPadded
+	BucketPadded = bucketPadded
 )
 
 func EnableAssertions() {

--- a/map_test.go
+++ b/map_test.go
@@ -60,7 +60,7 @@ func TestMap_BucketOfStructSize(t *testing.T) {
 }
 
 func TestMapOf_MissingEntry(t *testing.T) {
-	m := NewMapOf[string, string]()
+	m := NewMap[string, string]()
 	v, ok := m.Load("foo")
 	if ok {
 		t.Fatalf("value was not expected: %v", v)
@@ -74,7 +74,7 @@ func TestMapOf_MissingEntry(t *testing.T) {
 }
 
 func TestMapOf_EmptyStringKey(t *testing.T) {
-	m := NewMapOf[string, string]()
+	m := NewMap[string, string]()
 	m.Store("", "foobar")
 	v, ok := m.Load("")
 	if !ok {
@@ -86,7 +86,7 @@ func TestMapOf_EmptyStringKey(t *testing.T) {
 }
 
 func TestMapOfStore_NilValue(t *testing.T) {
-	m := NewMapOf[string, *struct{}]()
+	m := NewMap[string, *struct{}]()
 	m.Store("foo", nil)
 	v, ok := m.Load("foo")
 	if !ok {
@@ -98,7 +98,7 @@ func TestMapOfStore_NilValue(t *testing.T) {
 }
 
 func TestMapOfLoadOrStore_NilValue(t *testing.T) {
-	m := NewMapOf[string, *struct{}]()
+	m := NewMap[string, *struct{}]()
 	m.LoadOrStore("foo", nil)
 	v, loaded := m.LoadOrStore("foo", nil)
 	if !loaded {
@@ -111,7 +111,7 @@ func TestMapOfLoadOrStore_NilValue(t *testing.T) {
 
 func TestMapOfLoadOrStore_NonNilValue(t *testing.T) {
 	type foo struct{}
-	m := NewMapOf[string, *foo]()
+	m := NewMap[string, *foo]()
 	newv := &foo{}
 	v, loaded := m.LoadOrStore("foo", newv)
 	if loaded {
@@ -131,7 +131,7 @@ func TestMapOfLoadOrStore_NonNilValue(t *testing.T) {
 }
 
 func TestMapOfLoadAndStore_NilValue(t *testing.T) {
-	m := NewMapOf[string, *struct{}]()
+	m := NewMap[string, *struct{}]()
 	m.LoadAndStore("foo", nil)
 	v, loaded := m.LoadAndStore("foo", nil)
 	if !loaded {
@@ -150,7 +150,7 @@ func TestMapOfLoadAndStore_NilValue(t *testing.T) {
 }
 
 func TestMapOfLoadAndStore_NonNilValue(t *testing.T) {
-	m := NewMapOf[string, int]()
+	m := NewMap[string, int]()
 	v1 := 1
 	v, loaded := m.LoadAndStore("foo", v1)
 	if loaded {
@@ -178,7 +178,7 @@ func TestMapOfLoadAndStore_NonNilValue(t *testing.T) {
 
 func TestMapOfRange(t *testing.T) {
 	const numEntries = 1000
-	m := NewMapOf[string, int]()
+	m := NewMap[string, int]()
 	for i := 0; i < numEntries; i++ {
 		m.Store(strconv.Itoa(i), i)
 	}
@@ -204,7 +204,7 @@ func TestMapOfRange(t *testing.T) {
 }
 
 func TestMapOfRange_FalseReturned(t *testing.T) {
-	m := NewMapOf[string, int]()
+	m := NewMap[string, int]()
 	for i := 0; i < 100; i++ {
 		m.Store(strconv.Itoa(i), i)
 	}
@@ -220,7 +220,7 @@ func TestMapOfRange_FalseReturned(t *testing.T) {
 
 func TestMapOfRange_NestedDelete(t *testing.T) {
 	const numEntries = 256
-	m := NewMapOf[string, int]()
+	m := NewMap[string, int]()
 	for i := 0; i < numEntries; i++ {
 		m.Store(strconv.Itoa(i), i)
 	}
@@ -237,7 +237,7 @@ func TestMapOfRange_NestedDelete(t *testing.T) {
 
 func TestMapOfStringStore(t *testing.T) {
 	const numEntries = 128
-	m := NewMapOf[string, int]()
+	m := NewMap[string, int]()
 	for i := 0; i < numEntries; i++ {
 		m.Store(strconv.Itoa(i), i)
 	}
@@ -254,7 +254,7 @@ func TestMapOfStringStore(t *testing.T) {
 
 func TestMapOfIntStore(t *testing.T) {
 	const numEntries = 128
-	m := NewMapOf[int, int]()
+	m := NewMap[int, int]()
 	for i := 0; i < numEntries; i++ {
 		m.Store(i, i)
 	}
@@ -271,7 +271,7 @@ func TestMapOfIntStore(t *testing.T) {
 
 func TestMapOfStore_StructKeys_IntValues(t *testing.T) {
 	const numEntries = 128
-	m := NewMapOf[point, int]()
+	m := NewMap[point, int]()
 	for i := 0; i < numEntries; i++ {
 		m.Store(point{int32(i), -int32(i)}, i)
 	}
@@ -288,7 +288,7 @@ func TestMapOfStore_StructKeys_IntValues(t *testing.T) {
 
 func TestMapOfStore_StructKeys_StructValues(t *testing.T) {
 	const numEntries = 128
-	m := NewMapOf[point, point]()
+	m := NewMap[point, point]()
 	for i := 0; i < numEntries; i++ {
 		m.Store(point{int32(i), -int32(i)}, point{-int32(i), int32(i)})
 	}
@@ -308,7 +308,7 @@ func TestMapOfStore_StructKeys_StructValues(t *testing.T) {
 
 func TestMapOfLoadOrStore(t *testing.T) {
 	const numEntries = 1000
-	m := NewMapOf[string, int]()
+	m := NewMap[string, int]()
 	for i := 0; i < numEntries; i++ {
 		m.Store(strconv.Itoa(i), i)
 	}
@@ -321,7 +321,7 @@ func TestMapOfLoadOrStore(t *testing.T) {
 
 func TestMapOfLoadOrCompute(t *testing.T) {
 	const numEntries = 1000
-	m := NewMapOf[string, int]()
+	m := NewMap[string, int]()
 	for i := 0; i < numEntries; i++ {
 		v, loaded := m.LoadOrCompute(strconv.Itoa(i), func() int {
 			return i
@@ -347,7 +347,7 @@ func TestMapOfLoadOrCompute(t *testing.T) {
 }
 
 func TestMapOfLoadOrCompute_FunctionCalledOnce(t *testing.T) {
-	m := NewMapOf[int, int]()
+	m := NewMap[int, int]()
 	for i := 0; i < 100; {
 		m.LoadOrCompute(i, func() (v int) {
 			v, i = i, i+1
@@ -364,7 +364,7 @@ func TestMapOfLoadOrCompute_FunctionCalledOnce(t *testing.T) {
 
 func TestMapOfLoadOrTryCompute(t *testing.T) {
 	const numEntries = 1000
-	m := NewMapOf[string, int]()
+	m := NewMap[string, int]()
 	for i := 0; i < numEntries; i++ {
 		v, loaded := m.LoadOrTryCompute(strconv.Itoa(i), func() (newValue int, cancel bool) {
 			return i, true
@@ -404,7 +404,7 @@ func TestMapOfLoadOrTryCompute(t *testing.T) {
 }
 
 func TestMapOfLoadOrTryCompute_FunctionCalledOnce(t *testing.T) {
-	m := NewMapOf[int, int]()
+	m := NewMap[int, int]()
 	for i := 0; i < 100; {
 		m.LoadOrTryCompute(i, func() (newValue int, cancel bool) {
 			newValue, i = i, i+1
@@ -420,7 +420,7 @@ func TestMapOfLoadOrTryCompute_FunctionCalledOnce(t *testing.T) {
 }
 
 func TestMapOfCompute(t *testing.T) {
-	m := NewMapOf[string, int]()
+	m := NewMap[string, int]()
 	// Store a new value.
 	v, ok := m.Compute("foobar", func(oldValue int, loaded bool) (newValue int, delete bool) {
 		if oldValue != 0 {
@@ -497,7 +497,7 @@ func TestMapOfCompute(t *testing.T) {
 
 func TestMapOfStringStoreThenDelete(t *testing.T) {
 	const numEntries = 1000
-	m := NewMapOf[string, int]()
+	m := NewMap[string, int]()
 	for i := 0; i < numEntries; i++ {
 		m.Store(strconv.Itoa(i), i)
 	}
@@ -511,7 +511,7 @@ func TestMapOfStringStoreThenDelete(t *testing.T) {
 
 func TestMapOfIntStoreThenDelete(t *testing.T) {
 	const numEntries = 1000
-	m := NewMapOf[int32, int32]()
+	m := NewMap[int32, int32]()
 	for i := 0; i < numEntries; i++ {
 		m.Store(int32(i), int32(i))
 	}
@@ -525,7 +525,7 @@ func TestMapOfIntStoreThenDelete(t *testing.T) {
 
 func TestMapOfStructStoreThenDelete(t *testing.T) {
 	const numEntries = 1000
-	m := NewMapOf[point, string]()
+	m := NewMap[point, string]()
 	for i := 0; i < numEntries; i++ {
 		m.Store(point{int32(i), 42}, strconv.Itoa(i))
 	}
@@ -539,7 +539,7 @@ func TestMapOfStructStoreThenDelete(t *testing.T) {
 
 func TestMapOfStringStoreThenLoadAndDelete(t *testing.T) {
 	const numEntries = 1000
-	m := NewMapOf[string, int]()
+	m := NewMap[string, int]()
 	for i := 0; i < numEntries; i++ {
 		m.Store(strconv.Itoa(i), i)
 	}
@@ -555,7 +555,7 @@ func TestMapOfStringStoreThenLoadAndDelete(t *testing.T) {
 
 func TestMapOfIntStoreThenLoadAndDelete(t *testing.T) {
 	const numEntries = 1000
-	m := NewMapOf[int, int]()
+	m := NewMap[int, int]()
 	for i := 0; i < numEntries; i++ {
 		m.Store(i, i)
 	}
@@ -571,7 +571,7 @@ func TestMapOfIntStoreThenLoadAndDelete(t *testing.T) {
 
 func TestMapOfStructStoreThenLoadAndDelete(t *testing.T) {
 	const numEntries = 1000
-	m := NewMapOf[point, int]()
+	m := NewMap[point, int]()
 	for i := 0; i < numEntries; i++ {
 		m.Store(point{42, int32(i)}, i)
 	}
@@ -587,7 +587,7 @@ func TestMapOfStructStoreThenLoadAndDelete(t *testing.T) {
 
 func TestMapOfStoreThenParallelDelete_DoesNotShrinkBelowMinTableLen(t *testing.T) {
 	const numEntries = 1000
-	m := NewMapOf[int, int]()
+	m := NewMap[int, int]()
 	for i := 0; i < numEntries; i++ {
 		m.Store(i, i)
 	}
@@ -616,7 +616,7 @@ func TestMapOfStoreThenParallelDelete_DoesNotShrinkBelowMinTableLen(t *testing.T
 	}
 }
 
-func sizeBasedOnTypedRange(m *MapOf[string, int]) int {
+func sizeBasedOnTypedRange(m *Map[string, int]) int {
 	size := 0
 	m.Range(func(key string, value int) bool {
 		size++
@@ -627,7 +627,7 @@ func sizeBasedOnTypedRange(m *MapOf[string, int]) int {
 
 func TestMapOfSize(t *testing.T) {
 	const numEntries = 1000
-	m := NewMapOf[string, int]()
+	m := NewMap[string, int]()
 	size := m.Size()
 	if size != 0 {
 		t.Fatalf("zero size expected: %d", size)
@@ -661,7 +661,7 @@ func TestMapOfSize(t *testing.T) {
 
 func TestMapOfClear(t *testing.T) {
 	const numEntries = 1000
-	m := NewMapOf[string, int]()
+	m := NewMap[string, int]()
 	for i := 0; i < numEntries; i++ {
 		m.Store(strconv.Itoa(i), i)
 	}
@@ -680,7 +680,7 @@ func TestMapOfClear(t *testing.T) {
 	}
 }
 
-func assertMapOfCapacity[K comparable, V any](t *testing.T, m *MapOf[K, V], expectedCap int) {
+func assertMapOfCapacity[K comparable, V any](t *testing.T, m *Map[K, V], expectedCap int) {
 	stats := m.Stats()
 	if stats.Capacity != expectedCap {
 		t.Fatalf("capacity was different from %d: %d", expectedCap, stats.Capacity)
@@ -688,23 +688,23 @@ func assertMapOfCapacity[K comparable, V any](t *testing.T, m *MapOf[K, V], expe
 }
 
 func TestNewMapOfPresized(t *testing.T) {
-	assertMapOfCapacity(t, NewMapOf[string, string](), DefaultMinMapOfTableCap)
+	assertMapOfCapacity(t, NewMap[string, string](), DefaultMinMapOfTableCap)
 	assertMapOfCapacity(t, NewMapOfPresized[string, string](0), DefaultMinMapOfTableCap)
-	assertMapOfCapacity(t, NewMapOf[string, string](WithPresize(0)), DefaultMinMapOfTableCap)
+	assertMapOfCapacity(t, NewMap[string, string](WithPresize(0)), DefaultMinMapOfTableCap)
 	assertMapOfCapacity(t, NewMapOfPresized[string, string](-100), DefaultMinMapOfTableCap)
-	assertMapOfCapacity(t, NewMapOf[string, string](WithPresize(-100)), DefaultMinMapOfTableCap)
+	assertMapOfCapacity(t, NewMap[string, string](WithPresize(-100)), DefaultMinMapOfTableCap)
 	assertMapOfCapacity(t, NewMapOfPresized[string, string](500), 1280)
-	assertMapOfCapacity(t, NewMapOf[string, string](WithPresize(500)), 1280)
+	assertMapOfCapacity(t, NewMap[string, string](WithPresize(500)), 1280)
 	assertMapOfCapacity(t, NewMapOfPresized[int, int](1_000_000), 2621440)
-	assertMapOfCapacity(t, NewMapOf[int, int](WithPresize(1_000_000)), 2621440)
+	assertMapOfCapacity(t, NewMap[int, int](WithPresize(1_000_000)), 2621440)
 	assertMapOfCapacity(t, NewMapOfPresized[point, point](100), 160)
-	assertMapOfCapacity(t, NewMapOf[point, point](WithPresize(100)), 160)
+	assertMapOfCapacity(t, NewMap[point, point](WithPresize(100)), 160)
 }
 
 func TestNewMapOfPresized_DoesNotShrinkBelowMinTableLen(t *testing.T) {
 	const minTableLen = 1024
 	const numEntries = int(minTableLen * EntriesPerMapOfBucket * MapLoadFactor)
-	m := NewMapOf[int, int](WithPresize(numEntries))
+	m := NewMap[int, int](WithPresize(numEntries))
 	for i := 0; i < 2*numEntries; i++ {
 		m.Store(i, i)
 	}
@@ -727,7 +727,7 @@ func TestNewMapOfPresized_DoesNotShrinkBelowMinTableLen(t *testing.T) {
 func TestNewMapOfGrowOnly_OnlyShrinksOnClear(t *testing.T) {
 	const minTableLen = 128
 	const numEntries = minTableLen * EntriesPerMapOfBucket
-	m := NewMapOf[int, int](WithPresize(numEntries), WithGrowOnly())
+	m := NewMap[int, int](WithPresize(numEntries), WithGrowOnly())
 
 	stats := m.Stats()
 	initialTableLen := stats.RootBuckets
@@ -758,7 +758,7 @@ func TestNewMapOfGrowOnly_OnlyShrinksOnClear(t *testing.T) {
 
 func TestMapOfResize(t *testing.T) {
 	const numEntries = 100_000
-	m := NewMapOf[string, int]()
+	m := NewMap[string, int]()
 
 	for i := 0; i < numEntries; i++ {
 		m.Store(strconv.Itoa(i), i)
@@ -806,7 +806,7 @@ func TestMapOfResize(t *testing.T) {
 
 func TestMapOfResize_CounterLenLimit(t *testing.T) {
 	const numEntries = 1_000_000
-	m := NewMapOf[string, string]()
+	m := NewMap[string, string]()
 
 	for i := 0; i < numEntries; i++ {
 		m.Store("foo"+strconv.Itoa(i), "bar"+strconv.Itoa(i))
@@ -821,7 +821,7 @@ func TestMapOfResize_CounterLenLimit(t *testing.T) {
 	}
 }
 
-func parallelSeqTypedResizer(m *MapOf[int, int], numEntries int, positive bool, cdone chan bool) {
+func parallelSeqTypedResizer(m *Map[int, int], numEntries int, positive bool, cdone chan bool) {
 	for i := 0; i < numEntries; i++ {
 		if positive {
 			m.Store(i, i)
@@ -834,7 +834,7 @@ func parallelSeqTypedResizer(m *MapOf[int, int], numEntries int, positive bool, 
 
 func TestMapOfParallelResize_GrowOnly(t *testing.T) {
 	const numEntries = 100_000
-	m := NewMapOf[int, int]()
+	m := NewMap[int, int]()
 	cdone := make(chan bool)
 	go parallelSeqTypedResizer(m, numEntries, true, cdone)
 	go parallelSeqTypedResizer(m, numEntries, false, cdone)
@@ -856,7 +856,7 @@ func TestMapOfParallelResize_GrowOnly(t *testing.T) {
 	}
 }
 
-func parallelRandTypedResizer(t *testing.T, m *MapOf[string, int], numIters, numEntries int, cdone chan bool) {
+func parallelRandTypedResizer(t *testing.T, m *Map[string, int], numIters, numEntries int, cdone chan bool) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for i := 0; i < numIters; i++ {
 		coin := r.Int63n(2)
@@ -874,7 +874,7 @@ func parallelRandTypedResizer(t *testing.T, m *MapOf[string, int], numIters, num
 func TestMapOfParallelResize(t *testing.T) {
 	const numIters = 1_000
 	const numEntries = 2 * EntriesPerMapOfBucket * DefaultMinMapTableLen
-	m := NewMapOf[string, int]()
+	m := NewMap[string, int]()
 	cdone := make(chan bool)
 	go parallelRandTypedResizer(t, m, numIters, numEntries, cdone)
 	go parallelRandTypedResizer(t, m, numIters, numEntries, cdone)
@@ -902,7 +902,7 @@ func TestMapOfParallelResize(t *testing.T) {
 	}
 }
 
-func parallelRandTypedClearer(t *testing.T, m *MapOf[string, int], numIters, numEntries int, cdone chan bool) {
+func parallelRandTypedClearer(t *testing.T, m *Map[string, int], numIters, numEntries int, cdone chan bool) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for i := 0; i < numIters; i++ {
 		coin := r.Int63n(2)
@@ -920,7 +920,7 @@ func parallelRandTypedClearer(t *testing.T, m *MapOf[string, int], numIters, num
 func TestMapOfParallelClear(t *testing.T) {
 	const numIters = 100
 	const numEntries = 1_000
-	m := NewMapOf[string, int]()
+	m := NewMap[string, int]()
 	cdone := make(chan bool)
 	go parallelRandTypedClearer(t, m, numIters, numEntries, cdone)
 	go parallelRandTypedClearer(t, m, numIters, numEntries, cdone)
@@ -938,7 +938,7 @@ func TestMapOfParallelClear(t *testing.T) {
 	}
 }
 
-func parallelSeqTypedStorer(t *testing.T, m *MapOf[string, int], storeEach, numIters, numEntries int, cdone chan bool) {
+func parallelSeqTypedStorer(t *testing.T, m *Map[string, int], storeEach, numIters, numEntries int, cdone chan bool) {
 	for i := 0; i < numIters; i++ {
 		for j := 0; j < numEntries; j++ {
 			if storeEach == 0 || j%storeEach == 0 {
@@ -963,7 +963,7 @@ func TestMapOfParallelStores(t *testing.T) {
 	const numStorers = 4
 	const numIters = 10_000
 	const numEntries = 100
-	m := NewMapOf[string, int]()
+	m := NewMap[string, int]()
 	cdone := make(chan bool)
 	for i := 0; i < numStorers; i++ {
 		go parallelSeqTypedStorer(t, m, i, numIters, numEntries, cdone)
@@ -984,7 +984,7 @@ func TestMapOfParallelStores(t *testing.T) {
 	}
 }
 
-func parallelRandTypedStorer(t *testing.T, m *MapOf[string, int], numIters, numEntries int, cdone chan bool) {
+func parallelRandTypedStorer(t *testing.T, m *Map[string, int], numIters, numEntries int, cdone chan bool) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for i := 0; i < numIters; i++ {
 		j := r.Intn(numEntries)
@@ -997,7 +997,7 @@ func parallelRandTypedStorer(t *testing.T, m *MapOf[string, int], numIters, numE
 	cdone <- true
 }
 
-func parallelRandTypedDeleter(t *testing.T, m *MapOf[string, int], numIters, numEntries int, cdone chan bool) {
+func parallelRandTypedDeleter(t *testing.T, m *Map[string, int], numIters, numEntries int, cdone chan bool) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for i := 0; i < numIters; i++ {
 		j := r.Intn(numEntries)
@@ -1010,7 +1010,7 @@ func parallelRandTypedDeleter(t *testing.T, m *MapOf[string, int], numIters, num
 	cdone <- true
 }
 
-func parallelTypedLoader(t *testing.T, m *MapOf[string, int], numIters, numEntries int, cdone chan bool) {
+func parallelTypedLoader(t *testing.T, m *Map[string, int], numIters, numEntries int, cdone chan bool) {
 	for i := 0; i < numIters; i++ {
 		for j := 0; j < numEntries; j++ {
 			// Due to atomic snapshots we must either see no entry, or a "<j>"/j pair.
@@ -1027,7 +1027,7 @@ func parallelTypedLoader(t *testing.T, m *MapOf[string, int], numIters, numEntri
 func TestMapOfAtomicSnapshot(t *testing.T) {
 	const numIters = 100_000
 	const numEntries = 100
-	m := NewMapOf[string, int]()
+	m := NewMap[string, int]()
 	cdone := make(chan bool)
 	// Update or delete random entry in parallel with loads.
 	go parallelRandTypedStorer(t, m, numIters, numEntries, cdone)
@@ -1043,7 +1043,7 @@ func TestMapOfParallelStoresAndDeletes(t *testing.T) {
 	const numWorkers = 2
 	const numIters = 100_000
 	const numEntries = 1000
-	m := NewMapOf[string, int]()
+	m := NewMap[string, int]()
 	cdone := make(chan bool)
 	// Update random entry in parallel with deletes.
 	for i := 0; i < numWorkers; i++ {
@@ -1056,7 +1056,7 @@ func TestMapOfParallelStoresAndDeletes(t *testing.T) {
 	}
 }
 
-func parallelTypedComputer(m *MapOf[uint64, uint64], numIters, numEntries int, cdone chan bool) {
+func parallelTypedComputer(m *Map[uint64, uint64], numIters, numEntries int, cdone chan bool) {
 	for i := 0; i < numIters; i++ {
 		for j := 0; j < numEntries; j++ {
 			m.Compute(uint64(j), func(oldValue uint64, loaded bool) (newValue uint64, delete bool) {
@@ -1070,7 +1070,7 @@ func parallelTypedComputer(m *MapOf[uint64, uint64], numIters, numEntries int, c
 func TestMapOfParallelComputes(t *testing.T) {
 	const numWorkers = 4 // Also stands for numEntries.
 	const numIters = 10_000
-	m := NewMapOf[uint64, uint64]()
+	m := NewMap[uint64, uint64]()
 	cdone := make(chan bool)
 	for i := 0; i < numWorkers; i++ {
 		go parallelTypedComputer(m, numIters, numWorkers, cdone)
@@ -1091,7 +1091,7 @@ func TestMapOfParallelComputes(t *testing.T) {
 	}
 }
 
-func parallelTypedRangeStorer(m *MapOf[int, int], numEntries int, stopFlag *int64, cdone chan bool) {
+func parallelTypedRangeStorer(m *Map[int, int], numEntries int, stopFlag *int64, cdone chan bool) {
 	for {
 		for i := 0; i < numEntries; i++ {
 			m.Store(i, i)
@@ -1103,7 +1103,7 @@ func parallelTypedRangeStorer(m *MapOf[int, int], numEntries int, stopFlag *int6
 	cdone <- true
 }
 
-func parallelTypedRangeDeleter(m *MapOf[int, int], numEntries int, stopFlag *int64, cdone chan bool) {
+func parallelTypedRangeDeleter(m *Map[int, int], numEntries int, stopFlag *int64, cdone chan bool) {
 	for {
 		for i := 0; i < numEntries; i++ {
 			m.Delete(i)
@@ -1150,7 +1150,7 @@ func TestMapOfParallelRange(t *testing.T) {
 	<-cdone
 }
 
-func parallelTypedShrinker(t *testing.T, m *MapOf[uint64, *point], numIters, numEntries int, stopFlag *int64, cdone chan bool) {
+func parallelTypedShrinker(t *testing.T, m *Map[uint64, *point], numIters, numEntries int, stopFlag *int64, cdone chan bool) {
 	for i := 0; i < numIters; i++ {
 		for j := 0; j < numEntries; j++ {
 			if p, loaded := m.LoadOrStore(uint64(j), &point{int32(j), int32(j)}); loaded {
@@ -1165,7 +1165,7 @@ func parallelTypedShrinker(t *testing.T, m *MapOf[uint64, *point], numIters, num
 	cdone <- true
 }
 
-func parallelTypedUpdater(t *testing.T, m *MapOf[uint64, *point], idx int, stopFlag *int64, cdone chan bool) {
+func parallelTypedUpdater(t *testing.T, m *Map[uint64, *point], idx int, stopFlag *int64, cdone chan bool) {
 	for atomic.LoadInt64(stopFlag) != 1 {
 		sleepUs := int(Fastrand() % 10)
 		if p, loaded := m.LoadOrStore(uint64(idx), &point{int32(idx), int32(idx)}); loaded {
@@ -1183,7 +1183,7 @@ func parallelTypedUpdater(t *testing.T, m *MapOf[uint64, *point], idx int, stopF
 func TestMapOfDoesNotLoseEntriesOnResize(t *testing.T) {
 	const numIters = 10_000
 	const numEntries = 128
-	m := NewMapOf[uint64, *point]()
+	m := NewMap[uint64, *point]()
 	cdone := make(chan bool)
 	stopFlag := int64(0)
 	go parallelTypedShrinker(t, m, numIters, numEntries, &stopFlag, cdone)
@@ -1198,7 +1198,7 @@ func TestMapOfDoesNotLoseEntriesOnResize(t *testing.T) {
 }
 
 func TestMapOfStats(t *testing.T) {
-	m := NewMapOf[int, int]()
+	m := NewMap[int, int]()
 
 	stats := m.Stats()
 	if stats.RootBuckets != DefaultMinMapTableLen {
@@ -1252,7 +1252,7 @@ func TestMapOfStats(t *testing.T) {
 }
 
 func TestToPlainMapOf_NilPointer(t *testing.T) {
-	pm := ToPlainMapOf[int, int](nil)
+	pm := ToPlainMap[int, int](nil)
 	if len(pm) != 0 {
 		t.Fatalf("got unexpected size of nil map copy: %d", len(pm))
 	}
@@ -1260,11 +1260,11 @@ func TestToPlainMapOf_NilPointer(t *testing.T) {
 
 func TestToPlainMapOf(t *testing.T) {
 	const numEntries = 1000
-	m := NewMapOf[int, int]()
+	m := NewMap[int, int]()
 	for i := 0; i < numEntries; i++ {
 		m.Store(i, i)
 	}
-	pm := ToPlainMapOf[int, int](m)
+	pm := ToPlainMap[int, int](m)
 	if len(pm) != numEntries {
 		t.Fatalf("got unexpected size of nil map copy: %d", len(pm))
 	}
@@ -1282,7 +1282,7 @@ func BenchmarkMapOf_NoWarmUp(b *testing.B) {
 			continue
 		}
 		b.Run(bc.name, func(b *testing.B) {
-			m := NewMapOf[string, int]()
+			m := NewMap[string, int]()
 			benchmarkMapOfStringKeys(b, func(k string) (int, bool) {
 				return m.Load(k)
 			}, func(k string, v int) {
@@ -1345,7 +1345,7 @@ func BenchmarkMapOfInt_NoWarmUp(b *testing.B) {
 			continue
 		}
 		b.Run(bc.name, func(b *testing.B) {
-			m := NewMapOf[int, int]()
+			m := NewMap[int, int]()
 			benchmarkMapOfIntKeys(b, func(k int) (int, bool) {
 				return m.Load(k)
 			}, func(k int, v int) {

--- a/map_test.go
+++ b/map_test.go
@@ -52,14 +52,14 @@ func runParallel(b *testing.B, benchFn func(pb *testing.PB)) {
 	b.ReportMetric(opsPerSec, "ops/s")
 }
 
-func TestMap_BucketOfStructSize(t *testing.T) {
-	size := unsafe.Sizeof(BucketOfPadded{})
+func TestMap_BucketStructSize(t *testing.T) {
+	size := unsafe.Sizeof(BucketPadded{})
 	if size != 64 {
 		t.Fatalf("size of 64B (one cache line) is expected, got: %d", size)
 	}
 }
 
-func TestMapOf_MissingEntry(t *testing.T) {
+func TestMap_MissingEntry(t *testing.T) {
 	m := NewMap[string, string]()
 	v, ok := m.Load("foo")
 	if ok {
@@ -73,7 +73,7 @@ func TestMapOf_MissingEntry(t *testing.T) {
 	}
 }
 
-func TestMapOf_EmptyStringKey(t *testing.T) {
+func TestMap_EmptyStringKey(t *testing.T) {
 	m := NewMap[string, string]()
 	m.Store("", "foobar")
 	v, ok := m.Load("")
@@ -85,7 +85,7 @@ func TestMapOf_EmptyStringKey(t *testing.T) {
 	}
 }
 
-func TestMapOfStore_NilValue(t *testing.T) {
+func TestMapStore_NilValue(t *testing.T) {
 	m := NewMap[string, *struct{}]()
 	m.Store("foo", nil)
 	v, ok := m.Load("foo")
@@ -97,7 +97,7 @@ func TestMapOfStore_NilValue(t *testing.T) {
 	}
 }
 
-func TestMapOfLoadOrStore_NilValue(t *testing.T) {
+func TestMapLoadOrStore_NilValue(t *testing.T) {
 	m := NewMap[string, *struct{}]()
 	m.LoadOrStore("foo", nil)
 	v, loaded := m.LoadOrStore("foo", nil)
@@ -109,7 +109,7 @@ func TestMapOfLoadOrStore_NilValue(t *testing.T) {
 	}
 }
 
-func TestMapOfLoadOrStore_NonNilValue(t *testing.T) {
+func TestMapLoadOrStore_NonNilValue(t *testing.T) {
 	type foo struct{}
 	m := NewMap[string, *foo]()
 	newv := &foo{}
@@ -130,7 +130,7 @@ func TestMapOfLoadOrStore_NonNilValue(t *testing.T) {
 	}
 }
 
-func TestMapOfLoadAndStore_NilValue(t *testing.T) {
+func TestMapLoadAndStore_NilValue(t *testing.T) {
 	m := NewMap[string, *struct{}]()
 	m.LoadAndStore("foo", nil)
 	v, loaded := m.LoadAndStore("foo", nil)
@@ -149,7 +149,7 @@ func TestMapOfLoadAndStore_NilValue(t *testing.T) {
 	}
 }
 
-func TestMapOfLoadAndStore_NonNilValue(t *testing.T) {
+func TestMapLoadAndStore_NonNilValue(t *testing.T) {
 	m := NewMap[string, int]()
 	v1 := 1
 	v, loaded := m.LoadAndStore("foo", v1)
@@ -176,7 +176,7 @@ func TestMapOfLoadAndStore_NonNilValue(t *testing.T) {
 	}
 }
 
-func TestMapOfRange(t *testing.T) {
+func TestMapRange(t *testing.T) {
 	const numEntries = 1000
 	m := NewMap[string, int]()
 	for i := 0; i < numEntries; i++ {
@@ -203,7 +203,7 @@ func TestMapOfRange(t *testing.T) {
 	}
 }
 
-func TestMapOfRange_FalseReturned(t *testing.T) {
+func TestMapRange_FalseReturned(t *testing.T) {
 	m := NewMap[string, int]()
 	for i := 0; i < 100; i++ {
 		m.Store(strconv.Itoa(i), i)
@@ -218,7 +218,7 @@ func TestMapOfRange_FalseReturned(t *testing.T) {
 	}
 }
 
-func TestMapOfRange_NestedDelete(t *testing.T) {
+func TestMapRange_NestedDelete(t *testing.T) {
 	const numEntries = 256
 	m := NewMap[string, int]()
 	for i := 0; i < numEntries; i++ {
@@ -235,7 +235,7 @@ func TestMapOfRange_NestedDelete(t *testing.T) {
 	}
 }
 
-func TestMapOfStringStore(t *testing.T) {
+func TestMapStringStore(t *testing.T) {
 	const numEntries = 128
 	m := NewMap[string, int]()
 	for i := 0; i < numEntries; i++ {
@@ -252,7 +252,7 @@ func TestMapOfStringStore(t *testing.T) {
 	}
 }
 
-func TestMapOfIntStore(t *testing.T) {
+func TestMapIntStore(t *testing.T) {
 	const numEntries = 128
 	m := NewMap[int, int]()
 	for i := 0; i < numEntries; i++ {
@@ -269,7 +269,7 @@ func TestMapOfIntStore(t *testing.T) {
 	}
 }
 
-func TestMapOfStore_StructKeys_IntValues(t *testing.T) {
+func TestMapStore_StructKeys_IntValues(t *testing.T) {
 	const numEntries = 128
 	m := NewMap[point, int]()
 	for i := 0; i < numEntries; i++ {
@@ -286,7 +286,7 @@ func TestMapOfStore_StructKeys_IntValues(t *testing.T) {
 	}
 }
 
-func TestMapOfStore_StructKeys_StructValues(t *testing.T) {
+func TestMapStore_StructKeys_StructValues(t *testing.T) {
 	const numEntries = 128
 	m := NewMap[point, point]()
 	for i := 0; i < numEntries; i++ {
@@ -306,7 +306,7 @@ func TestMapOfStore_StructKeys_StructValues(t *testing.T) {
 	}
 }
 
-func TestMapOfLoadOrStore(t *testing.T) {
+func TestMapLoadOrStore(t *testing.T) {
 	const numEntries = 1000
 	m := NewMap[string, int]()
 	for i := 0; i < numEntries; i++ {
@@ -319,7 +319,7 @@ func TestMapOfLoadOrStore(t *testing.T) {
 	}
 }
 
-func TestMapOfLoadOrCompute(t *testing.T) {
+func TestMapLoadOrCompute(t *testing.T) {
 	const numEntries = 1000
 	m := NewMap[string, int]()
 	for i := 0; i < numEntries; i++ {
@@ -346,7 +346,7 @@ func TestMapOfLoadOrCompute(t *testing.T) {
 	}
 }
 
-func TestMapOfLoadOrCompute_FunctionCalledOnce(t *testing.T) {
+func TestMapLoadOrCompute_FunctionCalledOnce(t *testing.T) {
 	m := NewMap[int, int]()
 	for i := 0; i < 100; {
 		m.LoadOrCompute(i, func() (v int) {
@@ -362,7 +362,7 @@ func TestMapOfLoadOrCompute_FunctionCalledOnce(t *testing.T) {
 	})
 }
 
-func TestMapOfLoadOrTryCompute(t *testing.T) {
+func TestMapLoadOrTryCompute(t *testing.T) {
 	const numEntries = 1000
 	m := NewMap[string, int]()
 	for i := 0; i < numEntries; i++ {
@@ -403,7 +403,7 @@ func TestMapOfLoadOrTryCompute(t *testing.T) {
 	}
 }
 
-func TestMapOfLoadOrTryCompute_FunctionCalledOnce(t *testing.T) {
+func TestMapLoadOrTryCompute_FunctionCalledOnce(t *testing.T) {
 	m := NewMap[int, int]()
 	for i := 0; i < 100; {
 		m.LoadOrTryCompute(i, func() (newValue int, cancel bool) {
@@ -419,7 +419,7 @@ func TestMapOfLoadOrTryCompute_FunctionCalledOnce(t *testing.T) {
 	})
 }
 
-func TestMapOfCompute(t *testing.T) {
+func TestMapCompute(t *testing.T) {
 	m := NewMap[string, int]()
 	// Store a new value.
 	v, ok := m.Compute("foobar", func(oldValue int, loaded bool) (newValue int, delete bool) {
@@ -495,7 +495,7 @@ func TestMapOfCompute(t *testing.T) {
 	}
 }
 
-func TestMapOfStringStoreThenDelete(t *testing.T) {
+func TestMapStringStoreThenDelete(t *testing.T) {
 	const numEntries = 1000
 	m := NewMap[string, int]()
 	for i := 0; i < numEntries; i++ {
@@ -509,7 +509,7 @@ func TestMapOfStringStoreThenDelete(t *testing.T) {
 	}
 }
 
-func TestMapOfIntStoreThenDelete(t *testing.T) {
+func TestMapIntStoreThenDelete(t *testing.T) {
 	const numEntries = 1000
 	m := NewMap[int32, int32]()
 	for i := 0; i < numEntries; i++ {
@@ -523,7 +523,7 @@ func TestMapOfIntStoreThenDelete(t *testing.T) {
 	}
 }
 
-func TestMapOfStructStoreThenDelete(t *testing.T) {
+func TestMapStructStoreThenDelete(t *testing.T) {
 	const numEntries = 1000
 	m := NewMap[point, string]()
 	for i := 0; i < numEntries; i++ {
@@ -537,7 +537,7 @@ func TestMapOfStructStoreThenDelete(t *testing.T) {
 	}
 }
 
-func TestMapOfStringStoreThenLoadAndDelete(t *testing.T) {
+func TestMapStringStoreThenLoadAndDelete(t *testing.T) {
 	const numEntries = 1000
 	m := NewMap[string, int]()
 	for i := 0; i < numEntries; i++ {
@@ -553,7 +553,7 @@ func TestMapOfStringStoreThenLoadAndDelete(t *testing.T) {
 	}
 }
 
-func TestMapOfIntStoreThenLoadAndDelete(t *testing.T) {
+func TestMapIntStoreThenLoadAndDelete(t *testing.T) {
 	const numEntries = 1000
 	m := NewMap[int, int]()
 	for i := 0; i < numEntries; i++ {
@@ -569,7 +569,7 @@ func TestMapOfIntStoreThenLoadAndDelete(t *testing.T) {
 	}
 }
 
-func TestMapOfStructStoreThenLoadAndDelete(t *testing.T) {
+func TestMapStructStoreThenLoadAndDelete(t *testing.T) {
 	const numEntries = 1000
 	m := NewMap[point, int]()
 	for i := 0; i < numEntries; i++ {
@@ -585,7 +585,7 @@ func TestMapOfStructStoreThenLoadAndDelete(t *testing.T) {
 	}
 }
 
-func TestMapOfStoreThenParallelDelete_DoesNotShrinkBelowMinTableLen(t *testing.T) {
+func TestMapStoreThenParallelDelete_DoesNotShrinkBelowMinTableLen(t *testing.T) {
 	const numEntries = 1000
 	m := NewMap[int, int]()
 	for i := 0; i < numEntries; i++ {
@@ -625,7 +625,7 @@ func sizeBasedOnTypedRange(m *Map[string, int]) int {
 	return size
 }
 
-func TestMapOfSize(t *testing.T) {
+func TestMapSize(t *testing.T) {
 	const numEntries = 1000
 	m := NewMap[string, int]()
 	size := m.Size()
@@ -659,7 +659,7 @@ func TestMapOfSize(t *testing.T) {
 	}
 }
 
-func TestMapOfClear(t *testing.T) {
+func TestMapClear(t *testing.T) {
 	const numEntries = 1000
 	m := NewMap[string, int]()
 	for i := 0; i < numEntries; i++ {
@@ -680,30 +680,25 @@ func TestMapOfClear(t *testing.T) {
 	}
 }
 
-func assertMapOfCapacity[K comparable, V any](t *testing.T, m *Map[K, V], expectedCap int) {
+func assertMapCapacity[K comparable, V any](t *testing.T, m *Map[K, V], expectedCap int) {
 	stats := m.Stats()
 	if stats.Capacity != expectedCap {
 		t.Fatalf("capacity was different from %d: %d", expectedCap, stats.Capacity)
 	}
 }
 
-func TestNewMapOfPresized(t *testing.T) {
-	assertMapOfCapacity(t, NewMap[string, string](), DefaultMinMapOfTableCap)
-	assertMapOfCapacity(t, NewMapOfPresized[string, string](0), DefaultMinMapOfTableCap)
-	assertMapOfCapacity(t, NewMap[string, string](WithPresize(0)), DefaultMinMapOfTableCap)
-	assertMapOfCapacity(t, NewMapOfPresized[string, string](-100), DefaultMinMapOfTableCap)
-	assertMapOfCapacity(t, NewMap[string, string](WithPresize(-100)), DefaultMinMapOfTableCap)
-	assertMapOfCapacity(t, NewMapOfPresized[string, string](500), 1280)
-	assertMapOfCapacity(t, NewMap[string, string](WithPresize(500)), 1280)
-	assertMapOfCapacity(t, NewMapOfPresized[int, int](1_000_000), 2621440)
-	assertMapOfCapacity(t, NewMap[int, int](WithPresize(1_000_000)), 2621440)
-	assertMapOfCapacity(t, NewMapOfPresized[point, point](100), 160)
-	assertMapOfCapacity(t, NewMap[point, point](WithPresize(100)), 160)
+func TestNewMapWithPresize(t *testing.T) {
+	assertMapCapacity(t, NewMap[string, string](), DefaultMinMapTableCap)
+	assertMapCapacity(t, NewMap[string, string](WithPresize(0)), DefaultMinMapTableCap)
+	assertMapCapacity(t, NewMap[string, string](WithPresize(-100)), DefaultMinMapTableCap)
+	assertMapCapacity(t, NewMap[string, string](WithPresize(500)), 1280)
+	assertMapCapacity(t, NewMap[int, int](WithPresize(1_000_000)), 2621440)
+	assertMapCapacity(t, NewMap[point, point](WithPresize(100)), 160)
 }
 
-func TestNewMapOfPresized_DoesNotShrinkBelowMinTableLen(t *testing.T) {
+func TestNewMapWithPresize_DoesNotShrinkBelowMinTableLen(t *testing.T) {
 	const minTableLen = 1024
-	const numEntries = int(minTableLen * EntriesPerMapOfBucket * MapLoadFactor)
+	const numEntries = int(minTableLen * EntriesPerMapBucket * MapLoadFactor)
 	m := NewMap[int, int](WithPresize(numEntries))
 	for i := 0; i < 2*numEntries; i++ {
 		m.Store(i, i)
@@ -724,9 +719,9 @@ func TestNewMapOfPresized_DoesNotShrinkBelowMinTableLen(t *testing.T) {
 	}
 }
 
-func TestNewMapOfGrowOnly_OnlyShrinksOnClear(t *testing.T) {
+func TestNewMapGrowOnly_OnlyShrinksOnClear(t *testing.T) {
 	const minTableLen = 128
-	const numEntries = minTableLen * EntriesPerMapOfBucket
+	const numEntries = minTableLen * EntriesPerMapBucket
 	m := NewMap[int, int](WithPresize(numEntries), WithGrowOnly())
 
 	stats := m.Stats()
@@ -756,7 +751,7 @@ func TestNewMapOfGrowOnly_OnlyShrinksOnClear(t *testing.T) {
 	}
 }
 
-func TestMapOfResize(t *testing.T) {
+func TestMapResize(t *testing.T) {
 	const numEntries = 100_000
 	m := NewMap[string, int]()
 
@@ -767,7 +762,7 @@ func TestMapOfResize(t *testing.T) {
 	if stats.Size != numEntries {
 		t.Fatalf("size was too small: %d", stats.Size)
 	}
-	expectedCapacity := int(math.RoundToEven(MapLoadFactor+1)) * stats.RootBuckets * EntriesPerMapOfBucket
+	expectedCapacity := int(math.RoundToEven(MapLoadFactor+1)) * stats.RootBuckets * EntriesPerMapBucket
 	if stats.Capacity > expectedCapacity {
 		t.Fatalf("capacity was too large: %d, expected: %d", stats.Capacity, expectedCapacity)
 	}
@@ -791,7 +786,7 @@ func TestMapOfResize(t *testing.T) {
 	if stats.Size > 0 {
 		t.Fatalf("zero size was expected: %d", stats.Size)
 	}
-	expectedCapacity = stats.RootBuckets * EntriesPerMapOfBucket
+	expectedCapacity = stats.RootBuckets * EntriesPerMapBucket
 	if stats.Capacity != expectedCapacity {
 		t.Fatalf("capacity was too large: %d, expected: %d", stats.Capacity, expectedCapacity)
 	}
@@ -804,7 +799,7 @@ func TestMapOfResize(t *testing.T) {
 	t.Log(stats.ToString())
 }
 
-func TestMapOfResize_CounterLenLimit(t *testing.T) {
+func TestMapResize_CounterLenLimit(t *testing.T) {
 	const numEntries = 1_000_000
 	m := NewMap[string, string]()
 
@@ -832,7 +827,7 @@ func parallelSeqTypedResizer(m *Map[int, int], numEntries int, positive bool, cd
 	cdone <- true
 }
 
-func TestMapOfParallelResize_GrowOnly(t *testing.T) {
+func TestMapParallelResize_GrowOnly(t *testing.T) {
 	const numEntries = 100_000
 	m := NewMap[int, int]()
 	cdone := make(chan bool)
@@ -871,9 +866,9 @@ func parallelRandTypedResizer(t *testing.T, m *Map[string, int], numIters, numEn
 	cdone <- true
 }
 
-func TestMapOfParallelResize(t *testing.T) {
+func TestMapParallelResize(t *testing.T) {
 	const numIters = 1_000
-	const numEntries = 2 * EntriesPerMapOfBucket * DefaultMinMapTableLen
+	const numEntries = 2 * EntriesPerMapBucket * DefaultMinMapTableLen
 	m := NewMap[string, int]()
 	cdone := make(chan bool)
 	go parallelRandTypedResizer(t, m, numIters, numEntries, cdone)
@@ -917,7 +912,7 @@ func parallelRandTypedClearer(t *testing.T, m *Map[string, int], numIters, numEn
 	cdone <- true
 }
 
-func TestMapOfParallelClear(t *testing.T) {
+func TestMapParallelClear(t *testing.T) {
 	const numIters = 100
 	const numEntries = 1_000
 	m := NewMap[string, int]()
@@ -959,7 +954,7 @@ func parallelSeqTypedStorer(t *testing.T, m *Map[string, int], storeEach, numIte
 	cdone <- true
 }
 
-func TestMapOfParallelStores(t *testing.T) {
+func TestMapParallelStores(t *testing.T) {
 	const numStorers = 4
 	const numIters = 10_000
 	const numEntries = 100
@@ -1024,7 +1019,7 @@ func parallelTypedLoader(t *testing.T, m *Map[string, int], numIters, numEntries
 	cdone <- true
 }
 
-func TestMapOfAtomicSnapshot(t *testing.T) {
+func TestMapAtomicSnapshot(t *testing.T) {
 	const numIters = 100_000
 	const numEntries = 100
 	m := NewMap[string, int]()
@@ -1039,7 +1034,7 @@ func TestMapOfAtomicSnapshot(t *testing.T) {
 	}
 }
 
-func TestMapOfParallelStoresAndDeletes(t *testing.T) {
+func TestMapParallelStoresAndDeletes(t *testing.T) {
 	const numWorkers = 2
 	const numIters = 100_000
 	const numEntries = 1000
@@ -1067,7 +1062,7 @@ func parallelTypedComputer(m *Map[uint64, uint64], numIters, numEntries int, cdo
 	cdone <- true
 }
 
-func TestMapOfParallelComputes(t *testing.T) {
+func TestMapParallelComputes(t *testing.T) {
 	const numWorkers = 4 // Also stands for numEntries.
 	const numIters = 10_000
 	m := NewMap[uint64, uint64]()
@@ -1115,9 +1110,9 @@ func parallelTypedRangeDeleter(m *Map[int, int], numEntries int, stopFlag *int64
 	cdone <- true
 }
 
-func TestMapOfParallelRange(t *testing.T) {
+func TestMapParallelRange(t *testing.T) {
 	const numEntries = 10_000
-	m := NewMapOfPresized[int, int](numEntries)
+	m := NewMap[int, int](WithPresize(numEntries))
 	for i := 0; i < numEntries; i++ {
 		m.Store(i, i)
 	}
@@ -1180,7 +1175,7 @@ func parallelTypedUpdater(t *testing.T, m *Map[uint64, *point], idx int, stopFla
 	cdone <- true
 }
 
-func TestMapOfDoesNotLoseEntriesOnResize(t *testing.T) {
+func TestMapDoesNotLoseEntriesOnResize(t *testing.T) {
 	const numIters = 10_000
 	const numEntries = 128
 	m := NewMap[uint64, *point]()
@@ -1197,7 +1192,7 @@ func TestMapOfDoesNotLoseEntriesOnResize(t *testing.T) {
 	}
 }
 
-func TestMapOfStats(t *testing.T) {
+func TestMapStats(t *testing.T) {
 	m := NewMap[int, int]()
 
 	stats := m.Stats()
@@ -1210,7 +1205,7 @@ func TestMapOfStats(t *testing.T) {
 	if stats.EmptyBuckets != stats.RootBuckets {
 		t.Fatalf("unexpected number of empty buckets: %d", stats.EmptyBuckets)
 	}
-	if stats.Capacity != EntriesPerMapOfBucket*DefaultMinMapTableLen {
+	if stats.Capacity != EntriesPerMapBucket*DefaultMinMapTableLen {
 		t.Fatalf("unexpected capacity: %d", stats.Capacity)
 	}
 	if stats.Size != 0 {
@@ -1237,7 +1232,7 @@ func TestMapOfStats(t *testing.T) {
 	if stats.EmptyBuckets >= stats.RootBuckets {
 		t.Fatalf("unexpected number of empty buckets: %d", stats.EmptyBuckets)
 	}
-	if stats.Capacity < 2*EntriesPerMapOfBucket*DefaultMinMapTableLen {
+	if stats.Capacity < 2*EntriesPerMapBucket*DefaultMinMapTableLen {
 		t.Fatalf("unexpected capacity: %d", stats.Capacity)
 	}
 	if stats.Size != 200 {
@@ -1251,14 +1246,14 @@ func TestMapOfStats(t *testing.T) {
 	}
 }
 
-func TestToPlainMapOf_NilPointer(t *testing.T) {
+func TestToPlainMap_NilPointer(t *testing.T) {
 	pm := ToPlainMap[int, int](nil)
 	if len(pm) != 0 {
 		t.Fatalf("got unexpected size of nil map copy: %d", len(pm))
 	}
 }
 
-func TestToPlainMapOf(t *testing.T) {
+func TestToPlainMap(t *testing.T) {
 	const numEntries = 1000
 	m := NewMap[int, int]()
 	for i := 0; i < numEntries; i++ {
@@ -1275,7 +1270,7 @@ func TestToPlainMapOf(t *testing.T) {
 	}
 }
 
-func BenchmarkMapOf_NoWarmUp(b *testing.B) {
+func BenchmarkMap_NoWarmUp(b *testing.B) {
 	for _, bc := range benchmarkCases {
 		if bc.readPercentage == 100 {
 			// This benchmark doesn't make sense without a warm-up.
@@ -1283,7 +1278,7 @@ func BenchmarkMapOf_NoWarmUp(b *testing.B) {
 		}
 		b.Run(bc.name, func(b *testing.B) {
 			m := NewMap[string, int]()
-			benchmarkMapOfStringKeys(b, func(k string) (int, bool) {
+			benchmarkMapStringKeys(b, func(k string) (int, bool) {
 				return m.Load(k)
 			}, func(k string, v int) {
 				m.Store(k, v)
@@ -1294,15 +1289,15 @@ func BenchmarkMapOf_NoWarmUp(b *testing.B) {
 	}
 }
 
-func BenchmarkMapOf_WarmUp(b *testing.B) {
+func BenchmarkMap_WarmUp(b *testing.B) {
 	for _, bc := range benchmarkCases {
 		b.Run(bc.name, func(b *testing.B) {
-			m := NewMapOfPresized[string, int](benchmarkNumEntries)
+			m := NewMap[string, int](WithPresize(benchmarkNumEntries))
 			for i := 0; i < benchmarkNumEntries; i++ {
 				m.Store(benchmarkKeyPrefix+strconv.Itoa(i), i)
 			}
 			b.ResetTimer()
-			benchmarkMapOfStringKeys(b, func(k string) (int, bool) {
+			benchmarkMapStringKeys(b, func(k string) (int, bool) {
 				return m.Load(k)
 			}, func(k string, v int) {
 				m.Store(k, v)
@@ -1313,7 +1308,7 @@ func BenchmarkMapOf_WarmUp(b *testing.B) {
 	}
 }
 
-func benchmarkMapOfStringKeys(
+func benchmarkMapStringKeys(
 	b *testing.B,
 	loadFn func(k string) (int, bool),
 	storeFn func(k string, v int),
@@ -1338,7 +1333,7 @@ func benchmarkMapOfStringKeys(
 	})
 }
 
-func BenchmarkMapOfInt_NoWarmUp(b *testing.B) {
+func BenchmarkMapInt_NoWarmUp(b *testing.B) {
 	for _, bc := range benchmarkCases {
 		if bc.readPercentage == 100 {
 			// This benchmark doesn't make sense without a warm-up.
@@ -1346,7 +1341,7 @@ func BenchmarkMapOfInt_NoWarmUp(b *testing.B) {
 		}
 		b.Run(bc.name, func(b *testing.B) {
 			m := NewMap[int, int]()
-			benchmarkMapOfIntKeys(b, func(k int) (int, bool) {
+			benchmarkMapIntKeys(b, func(k int) (int, bool) {
 				return m.Load(k)
 			}, func(k int, v int) {
 				m.Store(k, v)
@@ -1357,15 +1352,15 @@ func BenchmarkMapOfInt_NoWarmUp(b *testing.B) {
 	}
 }
 
-func BenchmarkMapOfInt_WarmUp(b *testing.B) {
+func BenchmarkMapInt_WarmUp(b *testing.B) {
 	for _, bc := range benchmarkCases {
 		b.Run(bc.name, func(b *testing.B) {
-			m := NewMapOfPresized[int, int](benchmarkNumEntries)
+			m := NewMap[int, int](WithPresize(benchmarkNumEntries))
 			for i := 0; i < benchmarkNumEntries; i++ {
 				m.Store(i, i)
 			}
 			b.ResetTimer()
-			benchmarkMapOfIntKeys(b, func(k int) (int, bool) {
+			benchmarkMapIntKeys(b, func(k int) (int, bool) {
 				return m.Load(k)
 			}, func(k int, v int) {
 				m.Store(k, v)
@@ -1384,7 +1379,7 @@ func BenchmarkIntMapStandard_NoWarmUp(b *testing.B) {
 		}
 		b.Run(bc.name, func(b *testing.B) {
 			var m sync.Map
-			benchmarkMapOfIntKeys(b, func(k int) (value int, ok bool) {
+			benchmarkMapIntKeys(b, func(k int) (value int, ok bool) {
 				v, ok := m.Load(k)
 				if ok {
 					return v.(int), ok
@@ -1410,7 +1405,7 @@ func BenchmarkIntMapStandard_WarmUp(b *testing.B) {
 				m.Store(i, i)
 			}
 			b.ResetTimer()
-			benchmarkMapOfIntKeys(b, func(k int) (value int, ok bool) {
+			benchmarkMapIntKeys(b, func(k int) (value int, ok bool) {
 				v, ok := m.Load(k)
 				if ok {
 					return v.(int), ok
@@ -1426,7 +1421,7 @@ func BenchmarkIntMapStandard_WarmUp(b *testing.B) {
 	}
 }
 
-func benchmarkMapOfIntKeys(
+func benchmarkMapIntKeys(
 	b *testing.B,
 	loadFn func(k int) (int, bool),
 	storeFn func(k int, v int),
@@ -1451,8 +1446,8 @@ func benchmarkMapOfIntKeys(
 	})
 }
 
-func BenchmarkMapOfRange(b *testing.B) {
-	m := NewMapOfPresized[string, int](benchmarkNumEntries)
+func BenchmarkMapRange(b *testing.B) {
+	m := NewMap[string, int](WithPresize(benchmarkNumEntries))
 	for i := 0; i < benchmarkNumEntries; i++ {
 		m.Store(benchmarkKeys[i], i)
 	}

--- a/mpmcqueueof_test.go
+++ b/mpmcqueueof_test.go
@@ -14,14 +14,14 @@ import (
 	. "github.com/puzpuzpuz/xsync/v4"
 )
 
-func TestMPMCQueueOf_InvalidSize(t *testing.T) {
+func TestMPMCQueue_InvalidSize(t *testing.T) {
 	defer func() { recover() }()
-	NewMPMCQueueOf[int](0)
+	NewMPMCQueue[int](0)
 	t.Fatal("no panic detected")
 }
 
-func TestMPMCQueueOfEnqueueDequeueInt(t *testing.T) {
-	q := NewMPMCQueueOf[int](10)
+func TestMPMCQueueEnqueueDequeueInt(t *testing.T) {
+	q := NewMPMCQueue[int](10)
 	for i := 0; i < 10; i++ {
 		if !q.TryEnqueue(i) {
 			t.Fatalf("failed to enqueue for %d", i)
@@ -34,8 +34,8 @@ func TestMPMCQueueOfEnqueueDequeueInt(t *testing.T) {
 	}
 }
 
-func TestMPMCQueueOfEnqueueDequeueString(t *testing.T) {
-	q := NewMPMCQueueOf[string](10)
+func TestMPMCQueueEnqueueDequeueString(t *testing.T) {
+	q := NewMPMCQueue[string](10)
 	for i := 0; i < 10; i++ {
 		if !q.TryEnqueue(strconv.Itoa(i)) {
 			t.Fatalf("failed to enqueue for %d", i)
@@ -48,12 +48,12 @@ func TestMPMCQueueOfEnqueueDequeueString(t *testing.T) {
 	}
 }
 
-func TestMPMCQueueOfEnqueueDequeueStruct(t *testing.T) {
+func TestMPMCQueueEnqueueDequeueStruct(t *testing.T) {
 	type foo struct {
 		bar int
 		baz int
 	}
-	q := NewMPMCQueueOf[foo](10)
+	q := NewMPMCQueue[foo](10)
 	for i := 0; i < 10; i++ {
 		if !q.TryEnqueue(foo{i, i}) {
 			t.Fatalf("failed to enqueue for %d", i)
@@ -66,12 +66,12 @@ func TestMPMCQueueOfEnqueueDequeueStruct(t *testing.T) {
 	}
 }
 
-func TestMPMCQueueOfEnqueueDequeueStructRef(t *testing.T) {
+func TestMPMCQueueEnqueueDequeueStructRef(t *testing.T) {
 	type foo struct {
 		bar int
 		baz int
 	}
-	q := NewMPMCQueueOf[*foo](11)
+	q := NewMPMCQueue[*foo](11)
 	for i := 0; i < 10; i++ {
 		if !q.TryEnqueue(&foo{i, i}) {
 			t.Fatalf("failed to enqueue for %d", i)
@@ -90,8 +90,8 @@ func TestMPMCQueueOfEnqueueDequeueStructRef(t *testing.T) {
 	}
 }
 
-func TestMPMCQueueOfTryEnqueueDequeue(t *testing.T) {
-	q := NewMPMCQueueOf[int](10)
+func TestMPMCQueueTryEnqueueDequeue(t *testing.T) {
+	q := NewMPMCQueue[int](10)
 	for i := 0; i < 10; i++ {
 		if !q.TryEnqueue(i) {
 			t.Fatalf("failed to enqueue for %d", i)
@@ -104,8 +104,8 @@ func TestMPMCQueueOfTryEnqueueDequeue(t *testing.T) {
 	}
 }
 
-func TestMPMCQueueOfTryEnqueueOnFull(t *testing.T) {
-	q := NewMPMCQueueOf[string](1)
+func TestMPMCQueueTryEnqueueOnFull(t *testing.T) {
+	q := NewMPMCQueue[string](1)
 	if !q.TryEnqueue("foo") {
 		t.Error("failed to enqueue initial item")
 	}
@@ -114,16 +114,16 @@ func TestMPMCQueueOfTryEnqueueOnFull(t *testing.T) {
 	}
 }
 
-func TestMPMCQueueOfTryDequeueOnEmpty(t *testing.T) {
-	q := NewMPMCQueueOf[int](2)
+func TestMPMCQueueTryDequeueOnEmpty(t *testing.T) {
+	q := NewMPMCQueue[int](2)
 	if _, ok := q.TryDequeue(); ok {
 		t.Error("got success for enqueue on empty queue")
 	}
 }
 
-func hammerMPMCQueueOfNonBlockingCalls(t *testing.T, gomaxprocs, numOps, numThreads int) {
+func hammerMPMCQueueNonBlockingCalls(t *testing.T, gomaxprocs, numOps, numThreads int) {
 	runtime.GOMAXPROCS(gomaxprocs)
-	q := NewMPMCQueueOf[int](numThreads)
+	q := NewMPMCQueue[int](numThreads)
 	startwg := sync.WaitGroup{}
 	startwg.Add(1)
 	csum := make(chan int, numThreads)
@@ -174,18 +174,18 @@ func hammerMPMCQueueOfNonBlockingCalls(t *testing.T, gomaxprocs, numOps, numThre
 	}
 }
 
-func TestMPMCQueueOfNonBlockingCalls(t *testing.T) {
+func TestMPMCQueueNonBlockingCalls(t *testing.T) {
 	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(-1))
 	n := 10
 	if testing.Short() {
 		n = 1
 	}
-	hammerMPMCQueueOfNonBlockingCalls(t, 1, n, n)
-	hammerMPMCQueueOfNonBlockingCalls(t, 2, 10*n, 2*n)
-	hammerMPMCQueueOfNonBlockingCalls(t, 4, 100*n, 4*n)
+	hammerMPMCQueueNonBlockingCalls(t, 1, n, n)
+	hammerMPMCQueueNonBlockingCalls(t, 2, 10*n, 2*n)
+	hammerMPMCQueueNonBlockingCalls(t, 4, 100*n, 4*n)
 }
 
-func benchmarkMPMCQueueOf(b *testing.B, queueSize, localWork int) {
+func benchmarkMPMCQueue(b *testing.B, queueSize, localWork int) {
 	callsPerSched := queueSize
 	procs := runtime.GOMAXPROCS(-1) / 2
 	if procs == 0 {
@@ -193,7 +193,7 @@ func benchmarkMPMCQueueOf(b *testing.B, queueSize, localWork int) {
 	}
 	N := int32(b.N / callsPerSched)
 	c := make(chan bool, 2*procs)
-	q := NewMPMCQueueOf[int](queueSize)
+	q := NewMPMCQueue[int](queueSize)
 	for p := 0; p < procs; p++ {
 		go func() {
 			foo := 0
@@ -244,10 +244,10 @@ func benchmarkMPMCQueueOf(b *testing.B, queueSize, localWork int) {
 	}
 }
 
-func BenchmarkMPMCQueueOf(b *testing.B) {
-	benchmarkMPMCQueueOf(b, 1000, 0)
+func BenchmarkMPMCQueue(b *testing.B) {
+	benchmarkMPMCQueue(b, 1000, 0)
 }
 
-func BenchmarkMPMCQueueOfWork100(b *testing.B) {
-	benchmarkMPMCQueueOf(b, 1000, 100)
+func BenchmarkMPMCQueueWork100(b *testing.B) {
+	benchmarkMPMCQueue(b, 1000, 100)
 }

--- a/spscqueueof.go
+++ b/spscqueueof.go
@@ -4,17 +4,20 @@ import (
 	"sync/atomic"
 )
 
-// A SPSCQueueOf is a bounded single-producer single-consumer concurrent
+// Deprecated: use [SPSCQueue].
+type SPSCQueueOf[I any] = SPSCQueue[I]
+
+// A SPSCQueue is a bounded single-producer single-consumer concurrent
 // queue. This means that not more than a single goroutine must be
 // publishing items to the queue while not more than a single goroutine
 // must be consuming those items.
 //
-// SPSCQueueOf instances must be created with NewSPSCQueueOf function.
-// A SPSCQueueOf must not be copied after first use.
+// SPSCQueue instances must be created with NewSPSCQueue function.
+// A SPSCQueue must not be copied after first use.
 //
 // Based on the data structure from the following article:
 // https://rigtorp.se/ringbuffer/
-type SPSCQueueOf[I any] struct {
+type SPSCQueue[I any] struct {
 	cap  uint64
 	pidx uint64
 	//lint:ignore U1000 prevents false sharing
@@ -31,13 +34,18 @@ type SPSCQueueOf[I any] struct {
 	items []I
 }
 
-// NewSPSCQueueOf creates a new SPSCQueueOf instance with the given
+// Deprecated: use [NewSPSCQueue].
+func NewSPSCQueueOf[I any](capacity int) *SPSCQueue[I] {
+	return NewSPSCQueue[I](capacity)
+}
+
+// NewSPSCQueue creates a new SPSCQueue instance with the given
 // capacity.
-func NewSPSCQueueOf[I any](capacity int) *SPSCQueueOf[I] {
+func NewSPSCQueue[I any](capacity int) *SPSCQueue[I] {
 	if capacity < 1 {
 		panic("capacity must be positive number")
 	}
-	return &SPSCQueueOf[I]{
+	return &SPSCQueue[I]{
 		cap:   uint64(capacity + 1),
 		items: make([]I, capacity+1),
 	}
@@ -46,7 +54,7 @@ func NewSPSCQueueOf[I any](capacity int) *SPSCQueueOf[I] {
 // TryEnqueue inserts the given item into the queue. Does not block
 // and returns immediately. The result indicates that the queue isn't
 // full and the item was inserted.
-func (q *SPSCQueueOf[I]) TryEnqueue(item I) bool {
+func (q *SPSCQueue[I]) TryEnqueue(item I) bool {
 	// relaxed memory order would be enough here
 	idx := atomic.LoadUint64(&q.pidx)
 	next_idx := idx + 1
@@ -69,7 +77,7 @@ func (q *SPSCQueueOf[I]) TryEnqueue(item I) bool {
 // TryDequeue retrieves and removes the item from the head of the
 // queue. Does not block and returns immediately. The ok result
 // indicates that the queue isn't empty and an item was retrieved.
-func (q *SPSCQueueOf[I]) TryDequeue() (item I, ok bool) {
+func (q *SPSCQueue[I]) TryDequeue() (item I, ok bool) {
 	// relaxed memory order would be enough here
 	idx := atomic.LoadUint64(&q.cidx)
 	cached_idx := q.pcachedIdx

--- a/spscqueueof_test.go
+++ b/spscqueueof_test.go
@@ -16,12 +16,12 @@ import (
 
 func TestSPSCQueueOf_InvalidSize(t *testing.T) {
 	defer func() { recover() }()
-	NewSPSCQueueOf[int](0)
+	NewSPSCQueue[int](0)
 	t.Fatal("no panic detected")
 }
 
 func TestSPSCQueueOfTryEnqueueDequeueInt(t *testing.T) {
-	q := NewSPSCQueueOf[int](10)
+	q := NewSPSCQueue[int](10)
 	for i := 0; i < 10; i++ {
 		if !q.TryEnqueue(i) {
 			t.Fatal("TryEnqueue failed")
@@ -35,7 +35,7 @@ func TestSPSCQueueOfTryEnqueueDequeueInt(t *testing.T) {
 }
 
 func TestSPSCQueueOfTryEnqueueDequeueString(t *testing.T) {
-	q := NewSPSCQueueOf[string](10)
+	q := NewSPSCQueue[string](10)
 	for i := 0; i < 10; i++ {
 		if !q.TryEnqueue(strconv.Itoa(i)) {
 			t.Fatal("TryEnqueue failed")
@@ -53,7 +53,7 @@ func TestSPSCQueueOfTryEnqueueDequeueStruct(t *testing.T) {
 		bar int
 		baz int
 	}
-	q := NewSPSCQueueOf[foo](10)
+	q := NewSPSCQueue[foo](10)
 	for i := 0; i < 10; i++ {
 		if !q.TryEnqueue(foo{i, i}) {
 			t.Fatal("TryEnqueue failed")
@@ -71,7 +71,7 @@ func TestSPSCQueueOfTryEnqueueDequeueStructRef(t *testing.T) {
 		bar int
 		baz int
 	}
-	q := NewSPSCQueueOf[*foo](11)
+	q := NewSPSCQueue[*foo](11)
 	for i := 0; i < 10; i++ {
 		if !q.TryEnqueue(&foo{i, i}) {
 			t.Fatal("TryEnqueue failed")
@@ -91,7 +91,7 @@ func TestSPSCQueueOfTryEnqueueDequeueStructRef(t *testing.T) {
 }
 
 func TestSPSCQueueOfTryEnqueueDequeue(t *testing.T) {
-	q := NewSPSCQueueOf[int](10)
+	q := NewSPSCQueue[int](10)
 	for i := 0; i < 10; i++ {
 		if !q.TryEnqueue(i) {
 			t.Fatalf("failed to enqueue for %d", i)
@@ -105,7 +105,7 @@ func TestSPSCQueueOfTryEnqueueDequeue(t *testing.T) {
 }
 
 func TestSPSCQueueOfTryEnqueueOnFull(t *testing.T) {
-	q := NewSPSCQueueOf[string](1)
+	q := NewSPSCQueue[string](1)
 	if !q.TryEnqueue("foo") {
 		t.Error("failed to enqueue initial item")
 	}
@@ -115,14 +115,14 @@ func TestSPSCQueueOfTryEnqueueOnFull(t *testing.T) {
 }
 
 func TestSPSCQueueOfTryDequeueOnEmpty(t *testing.T) {
-	q := NewSPSCQueueOf[int](2)
+	q := NewSPSCQueue[int](2)
 	if _, ok := q.TryDequeue(); ok {
 		t.Error("got success for enqueue on empty queue")
 	}
 }
 
 func hammerSPSCQueueOfNonBlockingCalls(t *testing.T, cap, numOps int) {
-	q := NewSPSCQueueOf[int](cap)
+	q := NewSPSCQueue[int](cap)
 	startwg := sync.WaitGroup{}
 	startwg.Add(1)
 	csum := make(chan int, 2)
@@ -179,7 +179,7 @@ func benchmarkSPSCQueueOfProdCons(b *testing.B, queueSize, localWork int) {
 	callsPerSched := queueSize
 	N := int32(b.N / callsPerSched)
 	c := make(chan bool, 2)
-	q := NewSPSCQueueOf[int](queueSize)
+	q := NewSPSCQueue[int](queueSize)
 
 	go func() {
 		foo := 0


### PR DESCRIPTION
See https://github.com/puzpuzpuz/xsync/pull/163#discussion_r2020419080 for more details. This new major version can be used to rename `MapOf` to `Map`.