### PR TITLE
Remove usage of `unsafe.Pointer` in `Map` wherever possible

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -9,7 +9,7 @@ const (
 )
 
 type (
-	BucketPadded = bucketPadded
+	BucketPadded[K comparable, V any] = bucketPadded[K, V]
 )
 
 func EnableAssertions() {

--- a/map_test.go
+++ b/map_test.go
@@ -53,7 +53,11 @@ func runParallel(b *testing.B, benchFn func(pb *testing.PB)) {
 }
 
 func TestMap_BucketStructSize(t *testing.T) {
-	size := unsafe.Sizeof(BucketPadded{})
+	size := unsafe.Sizeof(BucketPadded[string, int64]{})
+	if size != 64 {
+		t.Fatalf("size of 64B (one cache line) is expected, got: %d", size)
+	}
+	size = unsafe.Sizeof(BucketPadded[struct{}, int32]{})
 	if size != 64 {
 		t.Fatalf("size of 64B (one cache line) is expected, got: %d", size)
 	}


### PR DESCRIPTION
Using `unsafe.Pointer` has obvious pitfalls, but was effectively required before the introduction of `atomic.Pointer`. So this code replaces that, and generally cleans up usage of `atomic.Load`, since it's discouraged in favor of `atomic.Pointer`. This change replaces pretty much all usages of it for `Map` (not the other data structures).

The benchmark results indicate that this has no performance impact, which is expected since the code is semantically unchanged.

```
goos: linux
goarch: amd64
pkg: github.com/puzpuzpuz/xsync/v4
cpu: AMD EPYC 7763 64-Core Processor
                            │   unsafe    │                safe                │
                            │   sec/op    │   sec/op     vs base               │
Map_NoWarmUp/reads=99%-8      7.974n ± 3%   8.069n ± 1%  +1.20% (p=0.014 n=10)
Map_NoWarmUp/reads=90%-8      10.59n ± 3%   10.75n ± 3%       ~ (p=0.085 n=10)
Map_NoWarmUp/reads=75%-8      13.57n ± 2%   13.56n ± 4%       ~ (p=0.810 n=10)
Map_WarmUp/reads=100%-8       8.489n ± 1%   8.525n ± 0%  +0.43% (p=0.030 n=10)
Map_WarmUp/reads=99%-8        7.679n ± 0%   7.731n ± 0%  +0.68% (p=0.004 n=10)
Map_WarmUp/reads=90%-8        9.643n ± 1%   9.697n ± 2%       ~ (p=0.105 n=10)
Map_WarmUp/reads=75%-8        12.32n ± 1%   12.38n ± 1%       ~ (p=0.107 n=10)
MapInt_NoWarmUp/reads=99%-8   6.673n ± 1%   6.713n ± 2%  +0.60% (p=0.035 n=10)
MapInt_NoWarmUp/reads=90%-8   9.127n ± 4%   9.377n ± 9%       ~ (p=0.089 n=10)
MapInt_NoWarmUp/reads=75%-8   11.90n ± 5%   11.87n ± 3%       ~ (p=0.957 n=10)
MapInt_WarmUp/reads=100%-8    5.332n ± 0%   5.332n ± 0%       ~ (p=0.897 n=10)
MapInt_WarmUp/reads=99%-8     6.353n ± 0%   6.404n ± 1%  +0.81% (p=0.000 n=10)
MapInt_WarmUp/reads=90%-8     8.108n ± 1%   8.269n ± 4%  +1.97% (p=0.001 n=10)
MapInt_WarmUp/reads=75%-8     10.56n ± 3%   10.75n ± 1%  +1.75% (p=0.029 n=10)
MapRange-8                    3.042µ ± 1%   3.039µ ± 2%       ~ (p=0.566 n=10)
Compute/op=UpdateOp-8         27.34n ± 0%   27.72n ± 0%  +1.39% (p=0.001 n=10)
Compute/op=NoOp-8             14.85n ± 0%   13.98n ± 0%  -5.83% (p=0.000 n=10)
geomean                       13.77n        13.83n       +0.45%

                            │   unsafe    │                safe                │
                            │    ops/s    │    ops/s     vs base               │
Map_NoWarmUp/reads=99%-8      125.4M ± 3%   123.9M ± 1%  -1.19% (p=0.015 n=10)
Map_NoWarmUp/reads=90%-8      94.46M ± 3%   93.05M ± 3%       ~ (p=0.105 n=10)
Map_NoWarmUp/reads=75%-8      73.71M ± 2%   73.73M ± 4%       ~ (p=0.853 n=10)
Map_WarmUp/reads=100%-8       117.8M ± 1%   117.3M ± 0%  -0.43% (p=0.029 n=10)
Map_WarmUp/reads=99%-8        130.2M ± 0%   129.4M ± 0%  -0.68% (p=0.004 n=10)
Map_WarmUp/reads=90%-8        103.7M ± 1%   103.1M ± 2%       ~ (p=0.105 n=10)
Map_WarmUp/reads=75%-8        81.16M ± 1%   80.76M ± 1%       ~ (p=0.105 n=10)
MapInt_NoWarmUp/reads=99%-8   149.9M ± 1%   149.0M ± 2%  -0.59% (p=0.035 n=10)
MapInt_NoWarmUp/reads=90%-8   109.6M ± 4%   106.6M ± 9%       ~ (p=0.089 n=10)
MapInt_NoWarmUp/reads=75%-8   84.06M ± 5%   84.29M ± 3%       ~ (p=0.971 n=10)
MapInt_WarmUp/reads=100%-8    187.6M ± 0%   187.6M ± 0%       ~ (p=0.912 n=10)
MapInt_WarmUp/reads=99%-8     157.4M ± 0%   156.2M ± 1%  -0.81% (p=0.000 n=10)
MapInt_WarmUp/reads=90%-8     123.3M ± 1%   120.9M ± 4%  -1.93% (p=0.001 n=10)
MapInt_WarmUp/reads=75%-8     94.66M ± 3%   93.01M ± 1%  -1.74% (p=0.029 n=10)
MapRange-8                    328.7k ± 1%   329.0k ± 2%       ~ (p=0.529 n=10)
geomean                       76.40M        75.78M       -0.82%

                            │     unsafe     │                 safe                  │
                            │      B/op      │     B/op      vs base                 │
Map_NoWarmUp/reads=99%-8      0.000 ±   0%     0.000 ±   0%       ~ (p=1.000 n=10) ¹
Map_NoWarmUp/reads=90%-8      1.000 ±   0%     1.000 ±   0%       ~ (p=1.000 n=10) ¹
Map_NoWarmUp/reads=75%-8      3.000 ±  33%     3.000 ±   0%       ~ (p=0.303 n=10)
Map_WarmUp/reads=100%-8       0.000 ±   0%     0.000 ±   0%       ~ (p=1.000 n=10) ¹
Map_WarmUp/reads=99%-8        0.000 ±   0%     0.000 ±   0%       ~ (p=1.000 n=10) ¹
Map_WarmUp/reads=90%-8        1.000 ±   0%     1.000 ±   0%       ~ (p=1.000 n=10) ¹
Map_WarmUp/reads=75%-8        3.000 ±   0%     2.500 ±  20%       ~ (p=0.141 n=10)
MapInt_NoWarmUp/reads=99%-8   0.000 ±   0%     0.000 ±   0%       ~ (p=1.000 n=10) ¹
MapInt_NoWarmUp/reads=90%-8   0.000 ±   0%     0.000 ±   0%       ~ (p=1.000 n=10) ¹
MapInt_NoWarmUp/reads=75%-8   2.000 ±   0%     1.500 ±  33%       ~ (p=0.141 n=10)
MapInt_WarmUp/reads=100%-8    0.000 ±   0%     0.000 ±   0%       ~ (p=1.000 n=10) ¹
MapInt_WarmUp/reads=99%-8     0.000 ±   0%     0.000 ±   0%       ~ (p=1.000 n=10) ¹
MapInt_WarmUp/reads=90%-8     0.000 ±   0%     0.000 ±   0%       ~ (p=1.000 n=10) ¹
MapInt_WarmUp/reads=75%-8     1.000 ± 100%     1.000 ± 100%       ~ (p=1.000 n=10)
MapRange-8                    0.000 ±   0%     0.000 ±   0%       ~ (p=1.000 n=10) ¹
Compute/op=UpdateOp-8         1.000 ±   0%     1.000 ±   0%       ~ (p=1.000 n=10) ¹
Compute/op=NoOp-8             0.000 ±   0%     0.000 ±   0%       ~ (p=1.000 n=10) ¹
geomean                                    ²                 -2.73%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                            │    unsafe    │                safe                 │
                            │  allocs/op   │ allocs/op   vs base                 │
Map_NoWarmUp/reads=99%-8      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Map_NoWarmUp/reads=90%-8      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Map_NoWarmUp/reads=75%-8      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Map_WarmUp/reads=100%-8       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Map_WarmUp/reads=99%-8        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Map_WarmUp/reads=90%-8        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Map_WarmUp/reads=75%-8        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
MapInt_NoWarmUp/reads=99%-8   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
MapInt_NoWarmUp/reads=90%-8   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
MapInt_NoWarmUp/reads=75%-8   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
MapInt_WarmUp/reads=100%-8    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
MapInt_WarmUp/reads=99%-8     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
MapInt_WarmUp/reads=90%-8     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
MapInt_WarmUp/reads=75%-8     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
MapRange-8                    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Compute/op=UpdateOp-8         1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
Compute/op=NoOp-8             0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                  ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```