### PR TITLE
Replace doLoadOrCompute with a read-only path in doCompute

### DIFF
--- a/map.go
+++ b/map.go
@@ -244,6 +244,7 @@ func (m *Map[K, V]) Store(key K, value V) {
 			return value, UpdateOp
 		},
 		false,
+		0,
 	)
 }
 
@@ -251,11 +252,13 @@ func (m *Map[K, V]) Store(key K, value V) {
 // Otherwise, it stores and returns the given value.
 // The loaded result is true if the value was loaded, false if stored.
 func (m *Map[K, V]) LoadOrStore(key K, value V) (actual V, loaded bool) {
-	return m.doLoadOrCompute(
+	return m.doCompute(
 		key,
 		func(V, bool) (V, ComputeOp) {
 			return value, UpdateOp
 		},
+		false,
+		1,
 	)
 }
 
@@ -271,6 +274,7 @@ func (m *Map[K, V]) LoadAndStore(key K, value V) (actual V, loaded bool) {
 			return value, UpdateOp
 		},
 		false,
+		0,
 	)
 }
 
@@ -290,7 +294,7 @@ func (m *Map[K, V]) LoadOrCompute(
 	key K,
 	valueFn func() (newValue V, cancel bool),
 ) (value V, loaded bool) {
-	return m.doLoadOrCompute(
+	return m.doCompute(
 		key,
 		func(oldValue V, loaded bool) (V, ComputeOp) {
 			if loaded {
@@ -302,6 +306,8 @@ func (m *Map[K, V]) LoadOrCompute(
 			}
 			return oldValue, CancelOp
 		},
+		false,
+		1,
 	)
 }
 
@@ -345,7 +351,7 @@ func (m *Map[K, V]) Compute(
 	key K,
 	valueFn func(oldValue V, loaded bool) (newValue V, op ComputeOp),
 ) (actual V, ok bool) {
-	return m.doCompute(key, valueFn, true)
+	return m.doCompute(key, valueFn, true, 0)
 }
 
 // LoadAndDelete deletes the value for a key, returning the previous
@@ -358,6 +364,7 @@ func (m *Map[K, V]) LoadAndDelete(key K) (value V, loaded bool) {
 			return value, DeleteOp
 		},
 		false,
+		-1,
 	)
 }
 
@@ -369,6 +376,7 @@ func (m *Map[K, V]) Delete(key K) {
 			return value, DeleteOp
 		},
 		false,
+		-1,
 	)
 }
 
@@ -376,7 +384,9 @@ func (m *Map[K, V]) doCompute(
 	key K,
 	valueFn func(oldValue V, loaded bool) (V, ComputeOp),
 	computeOnly bool,
+	loadExitFlag int8,
 ) (V, bool) {
+
 	for {
 	compute_attempt:
 		var (
@@ -391,6 +401,36 @@ func (m *Map[K, V]) doCompute(
 		h2w := broadcast(h2)
 		bidx := uint64(len(table.buckets)-1) & h1
 		rootb := &table.buckets[bidx]
+
+		if loadExitFlag != 0 {
+			b := rootb
+		load:
+			for {
+				metaw := b.meta.Load()
+				markedw := markZeroBytes(metaw^h2w) & metaMask
+				for markedw != 0 {
+					idx := firstMarkedByteIndex(markedw)
+					e := b.entries[idx].Load()
+					if e != nil {
+						if e.key == key {
+							if loadExitFlag == 1 {
+								return e.value, true
+							}
+							break load
+						}
+					}
+					markedw &= markedw - 1
+				}
+				b = b.next.Load()
+				if b == nil {
+					if loadExitFlag == -1 {
+						return *new(V), false
+					}
+					break load
+				}
+			}
+		}
+
 		rootb.mu.Lock()
 		// The following two checks must go in reverse to what's
 		// in the resize method.
@@ -510,121 +550,6 @@ func (m *Map[K, V]) doCompute(
 					rootb.mu.Unlock()
 					table.addSize(bidx, 1)
 					return newValue, computeOnly
-				}
-			}
-			b = b.next.Load()
-		}
-	}
-}
-
-func (m *Map[K, V]) doLoadOrCompute(
-	key K,
-	valueFn func(oldValue V, loaded bool) (V, ComputeOp),
-) (V, bool) {
-	// Read-only path.
-	if v, ok := m.Load(key); ok {
-		return v, true
-	}
-	// Write path.
-	for {
-	compute_attempt:
-		var (
-			emptyb   *bucketPadded[K, V]
-			emptyidx int
-		)
-		table := m.table.Load()
-		tableLen := len(table.buckets)
-		hash := maphash.Comparable(table.seed, key)
-		h1 := h1(hash)
-		h2 := h2(hash)
-		h2w := broadcast(h2)
-		bidx := uint64(len(table.buckets)-1) & h1
-		rootb := &table.buckets[bidx]
-		rootb.mu.Lock()
-		// The following two checks must go in reverse to what's
-		// in the resize method.
-		if m.resizeInProgress() {
-			// Resize is in progress. Wait, then go for another attempt.
-			rootb.mu.Unlock()
-			m.waitForResize()
-			goto compute_attempt
-		}
-		if m.newerTableExists(table) {
-			// Someone resized the table. Go for another attempt.
-			rootb.mu.Unlock()
-			goto compute_attempt
-		}
-		b := rootb
-		for {
-			metaw := b.meta.Load()
-			markedw := markZeroBytes(metaw^h2w) & metaMask
-			for markedw != 0 {
-				idx := firstMarkedByteIndex(markedw)
-				e := b.entries[idx].Load()
-				if e != nil {
-					if e.key == key {
-						rootb.mu.Unlock()
-						return e.value, true
-					}
-				}
-				markedw &= markedw - 1
-			}
-			if emptyb == nil {
-				// Search for empty entries (up to 5 per bucket).
-				emptyw := metaw & defaultMetaMasked
-				if emptyw != 0 {
-					idx := firstMarkedByteIndex(emptyw)
-					emptyb = b
-					emptyidx = idx
-				}
-			}
-			if b.next.Load() == nil {
-				if emptyb != nil {
-					// Insertion into an existing bucket.
-					var zeroV V
-					newValue, op := valueFn(zeroV, false)
-					switch op {
-					case DeleteOp, CancelOp:
-						rootb.mu.Unlock()
-						return zeroV, false
-					default:
-						newe := new(entry[K, V])
-						newe.key = key
-						newe.value = newValue
-						// First we update meta, then the entry.
-						emptyb.meta.Store(setByte(emptyb.meta.Load(), h2, emptyidx))
-						emptyb.entries[emptyidx].Store(newe)
-						rootb.mu.Unlock()
-						table.addSize(bidx, 1)
-						return newValue, false
-					}
-				}
-				growThreshold := float64(tableLen) * entriesPerMapBucket * mapLoadFactor
-				if table.sumSize() > int64(growThreshold) {
-					// Need to grow the table. Then go for another attempt.
-					rootb.mu.Unlock()
-					m.resize(table, mapGrowHint)
-					goto compute_attempt
-				}
-				// Insertion into a new bucket.
-				var zeroV V
-				newValue, op := valueFn(zeroV, false)
-				switch op {
-				case DeleteOp, CancelOp:
-					rootb.mu.Unlock()
-					return newValue, false
-				default:
-					// Create and append a bucket.
-					newb := new(bucketPadded[K, V])
-					newb.meta.Store(setByte(defaultMeta, h2, 0))
-					newe := new(entry[K, V])
-					newe.key = key
-					newe.value = newValue
-					newb.entries[0].Store(newe)
-					b.next.Store(newb)
-					rootb.mu.Unlock()
-					table.addSize(bidx, 1)
-					return newValue, false
 				}
 			}
 			b = b.next.Load()

--- a/map.go
+++ b/map.go
@@ -254,7 +254,10 @@ func (m *Map[K, V]) Store(key K, value V) {
 func (m *Map[K, V]) LoadOrStore(key K, value V) (actual V, loaded bool) {
 	return m.doCompute(
 		key,
-		func(V, bool) (V, ComputeOp) {
+		func(oldValue V, loaded bool) (V, ComputeOp) {
+			if loaded {
+				return oldValue, CancelOp
+			}
 			return value, UpdateOp
 		},
 		false,


### PR DESCRIPTION
We can see improvements in both `LoadOrStore` and `Delete`, mainly due to the reuse of hash computations and other optimizations, accounting for both loading and deletion scenarios (with many repeated deletions). 

It seems the `doLoadOrCompute` function might not be necessary.


| Operation       | Implementation | 1 Record (ns/op) | 1M Records (ns/op) | 1B Records (ns/op) | Allocs/op (1B) |
|-----------------|----------------|------------------|--------------------|--------------------|----------------|
| **Store**       | xsync.MapOf    | 149.8            | 11.17              | 11.72              | 1              |
|                 | Map            | 153.0            | 11.40              | 11.61              | 1              |
| **LoadOrStore** | xsync.MapOf    | 0.3243           | 9.533              | 8.316              | 0              |
|                 | Map            | 0.3128           | **7.042**              | **6.525**              | 0              |
| **Load**        | xsync.MapOf    | 0.2347           | 1.614              | 1.627              | 0              |
|                 | Map            | 0.2329           | 1.639              | 1.603              | 0              |
| **Delete**      | xsync.MapOf    | 63.25            | 10.37              | 10.32              | 0              |
|                 | Map            | **0.2621**           | **0.8506**             | **0.8641**             | 0              |

( In reality, it's not possible to stress-test with 1 billion records—only tens of millions at most)

Additionally, regarding these two optimizations:

Single-record testing: Contention is almost entirely on a single bucket—an extreme scenario that rarely occurs in practice. However, this can be resolved in Store by filtering identical values.

LoadOrStore performance: Under larger datasets (~1M records), it runs slower than expected. Converting mu (the mutex) into a lighter spin lock can reduce latency(ns/op) by several times.

Both solutions have been trial-implemented in my other project: [pb](https://github.com/llxisdsh/pb)

---

1B
```
goos: windows
goarch: amd64
cpu: AMD Ryzen Threadripper 3970X 32-Core Processor 
BenchmarkStore_xsync_MapOf
BenchmarkStore_xsync_MapOf-64          	89069684	        11.72 ns/op	      16 B/op	       1 allocs/op
BenchmarkLoadOrStore_xsync_MapOf
BenchmarkLoadOrStore_xsync_MapOf-64    	125710188	         8.316 ns/op	       0 B/op	       0 allocs/op
BenchmarkLoad_xsync_MapOf
BenchmarkLoad_xsync_MapOf-64           	737704766	         1.627 ns/op	       0 B/op	       0 allocs/op
BenchmarkDelete_xsync_MapOf
BenchmarkDelete_xsync_MapOf-64         	100000000	        10.32 ns/op	       0 B/op	       0 allocs/op
BenchmarkStore_Map
BenchmarkStore_Map-64                  	99031023	        11.61 ns/op	      16 B/op	       1 allocs/op
BenchmarkLoadOrStore_Map
BenchmarkLoadOrStore_Map-64            	158022788	         6.525 ns/op	       0 B/op	       0 allocs/op
BenchmarkLoad_Map
BenchmarkLoad_Map-64                   	735018484	         1.603 ns/op	       0 B/op	       0 allocs/op
BenchmarkDelete_Map
BenchmarkDelete_Map-64                 	1000000000	         0.8641 ns/op	       0 B/op	       0 allocs/op
```

1M
```
goos: windows
goarch: amd64
cpu: AMD Ryzen Threadripper 3970X 32-Core Processor 
BenchmarkStore_xsync_MapOf
BenchmarkStore_xsync_MapOf-64          	102045298	        11.17 ns/op	      16 B/op	       1 allocs/op
BenchmarkLoadOrStore_xsync_MapOf
BenchmarkLoadOrStore_xsync_MapOf-64    	105065557	         9.533 ns/op	       0 B/op	       0 allocs/op
BenchmarkLoad_xsync_MapOf
BenchmarkLoad_xsync_MapOf-64           	736576356	         1.614 ns/op	       0 B/op	       0 allocs/op
BenchmarkDelete_xsync_MapOf
BenchmarkDelete_xsync_MapOf-64         	100000000	        10.37 ns/op	       0 B/op	       0 allocs/op
BenchmarkStore_Map
BenchmarkStore_Map-64                  	99094773	        11.40 ns/op	      16 B/op	       1 allocs/op
BenchmarkLoadOrStore_Map
BenchmarkLoadOrStore_Map-64            	155615542	         7.042 ns/op	       0 B/op	       0 allocs/op
BenchmarkLoad_Map
BenchmarkLoad_Map-64                   	714100387	         1.639 ns/op	       0 B/op	       0 allocs/op
BenchmarkDelete_Map
BenchmarkDelete_Map-64                 	1000000000	         0.8506 ns/op	       0 B/op	       0 allocs/op

```

1
```
BenchmarkStore_xsync_MapOf-64          	 8169705	       149.8 ns/op	      16 B/op	       1 allocs/op
BenchmarkLoadOrStore_xsync_MapOf
BenchmarkLoadOrStore_xsync_MapOf-64    	1000000000	         0.3243 ns/op	       0 B/op	       0 allocs/op
BenchmarkLoad_xsync_MapOf
BenchmarkLoad_xsync_MapOf-64           	1000000000	         0.2347 ns/op	       0 B/op	       0 allocs/op
BenchmarkDelete_xsync_MapOf
BenchmarkDelete_xsync_MapOf-64         	17854671	        63.25 ns/op	       0 B/op	       0 allocs/op
BenchmarkStore_Map
BenchmarkStore_Map-64                  	 8123190	       153.0 ns/op	      16 B/op	       1 allocs/op
BenchmarkLoadOrStore_Map
BenchmarkLoadOrStore_Map-64            	1000000000	         0.3128 ns/op	       0 B/op	       0 allocs/op
BenchmarkLoad_Map
BenchmarkLoad_Map-64                   	1000000000	         0.2329 ns/op	       0 B/op	       0 allocs/op
BenchmarkDelete_Map
BenchmarkDelete_Map-64                 	1000000000	         0.2621 ns/op	       0 B/op	       0 allocs/op
```