### PR TITLE
Parallel Map resize

### DIFF
--- a/map.go
+++ b/map.go
@@ -636,7 +636,7 @@ func (m *Map[K, V]) resize(knownTable *mapTable[K, V], hint mapResizeHint) {
 			for c := 0; c < chunks; c++ {
 				copyWg.Add(1)
 				go func(start, end int) {
-					for i := start; i < end && i < tableLen; i++ {
+					for i := start; i < end; i++ {
 						copied := copyBucketWithDestLock[K, V](&table.buckets[i], newTable)
 						if copied > 0 {
 							newTable.addSize(uint64(i), copied)


### PR DESCRIPTION
This commit enables the map to conditionally trigger parallel copying during resize, directly improving the performance of all write operations. Compared to other optimization methods, parallel resize is well-suited for the current map implementation. Here's a comparison:

1. **Incremental COW**: Lower overall throughput compared to parallel resize, non-conflicting logic but more complex code.
2. **Moving Mutex outside buckets**: Reduces lock false sharing, decreases write performance, improves read performance.
3. **Spinlock**: A more aggressive version of 2, significantly reduces lock false sharing, greatly boosts load performance, but carries some risks.
4. **Using a faster Go built-in hash**: A hacky approach that leverages Go's built-in keyHash and valEqual functions for slightly faster performance, particularly for loads, but doesn't align with the map's current robust design.
5. **Filtering duplicate values outside the lock during writes**: Relies on valEqual, yields dramatic improvements in some benchmarks but has limited impact in real-world applications.

Except for 1 and 2, my [pb](https://github.com/llxisdsh/pb)  project uses all the above methods.

Before implementing parallel resize, I considered enabling it via a `WithParallel` option. However, reducing resize latency is a common need for this type of map, and most projects run on multi-core systems where the benefits are noticeable. The primary bottleneck for resize remains CPU computation (hashing), not memory bus bandwidth (KV copying involves pointers), making this optimization meaningful.

The performance improvements of parallel resize are as follows, and we can observe the enhancements:

| Operation       | Data Size   | Map v4.0.0 (ns/op) | Fork (ns/op) | B/op | Allocs |
|:----------------|------------:|-------------------:|-------------:|-----:|-------:|
| **Store**       | 1           | 164.30             | 166.30       | 16   | 1      |
|                 | 100         | 53.75              | 52.79        | 16   | 1      |
|                 | 10000       | 19.48              | **17.16**    | 16   | 1      |
|                 | 1000000     | 12.14              | **8.22**     | 16   | 1      |
|                 | 1000000000  | 13.08              | **9.23**     | 16   | 1      |
| **LoadOrStore** | 1           | 0.34               | 0.33         | 0    | 0      |
|                 | 100         | 0.39               | 0.35         | 0    | 0      |
|                 | 10000       | 0.81               | **0.74**     | 0    | 0      |
|                 | 1000000     | 9.27               | **4.27**     | 0    | 0      |
|                 | 1000000000  | 13.66              | **9.73**     | 1    | 0      |
| **Load**        | 1           | 0.26               | 0.26         | 0    | 0      |
|                 | 100         | 0.28               | 0.27         | 0    | 0      |
|                 | 10000       | 0.30               | 0.30         | 0    | 0      |
|                 | 1000000     | 1.64               | 1.64         | 0    | 0      |
|                 | 1000000000  | 1.62               | 1.62         | 0    | 0      |
| **Delete**      | 1           | 64.94              | 0.27         | 0    | 0      |
|                 | 100         | 25.86              | 0.33         | 0    | 0      |
|                 | 10000       | 19.43              | 0.45         | 0    | 0      |
|                 | 1000000     | 10.36              | 0.82         | 0    | 0      |
|                 | 1000000000  | 10.24              | 0.80         | 0    | 0      |

(Load and Delete will prepare data for the number of test iterations by default, but will not exceed 1,000,000 entries.)

1
--
BenchmarkStore_xsync_MapOf-64                   	 7857902	       164.3 ns/op	      16 B/op	       1 allocs/op
BenchmarkLoadOrStore_xsync_MapOf
BenchmarkLoadOrStore_xsync_MapOf-64             	1000000000	         0.3485 ns/op	       0 B/op	       0 allocs/op
BenchmarkLoad_xsync_MapOf
BenchmarkLoad_xsync_MapOf-64                    	1000000000	         0.2626 ns/op	       0 B/op	       0 allocs/op
BenchmarkDelete_xsync_MapOf
BenchmarkDelete_xsync_MapOf-64                  	17305728	        64.94 ns/op	       0 B/op	       0 allocs/op
BenchmarkStore_llxisdsh_xsync_MapOf
BenchmarkStore_llxisdsh_xsync_MapOf-64          	 7246262	       166.3 ns/op	      16 B/op	       1 allocs/op
BenchmarkLoadOrStore_llxisdsh_xsync_MapOf
BenchmarkLoadOrStore_llxisdsh_xsync_MapOf-64    	1000000000	         0.3321 ns/op	       0 B/op	       0 allocs/op
BenchmarkLoad_llxisdsh_xsync_MapOf
BenchmarkLoad_llxisdsh_xsync_MapOf-64           	1000000000	         0.2609 ns/op	       0 B/op	       0 allocs/op
BenchmarkDelete_llxisdsh_xsync_MapOf
BenchmarkDelete_llxisdsh_xsync_MapOf-64         	1000000000	         0.2751 ns/op	       0 B/op	       0 allocs/op

100
--
BenchmarkStore_xsync_MapOf-64                   	22116634	        53.75 ns/op	      16 B/op	       1 allocs/op
BenchmarkLoadOrStore_xsync_MapOf
BenchmarkLoadOrStore_xsync_MapOf-64             	1000000000	         0.3998 ns/op	       0 B/op	       0 allocs/op
BenchmarkLoad_xsync_MapOf
BenchmarkLoad_xsync_MapOf-64                    	1000000000	         0.2872 ns/op	       0 B/op	       0 allocs/op
BenchmarkDelete_xsync_MapOf
BenchmarkDelete_xsync_MapOf-64                  	46963974	        25.86 ns/op	       0 B/op	       0 allocs/op
BenchmarkStore_llxisdsh_xsync_MapOf
BenchmarkStore_llxisdsh_xsync_MapOf-64          	21041815	        52.79 ns/op	      16 B/op	       1 allocs/op
BenchmarkLoadOrStore_llxisdsh_xsync_MapOf
BenchmarkLoadOrStore_llxisdsh_xsync_MapOf-64    	1000000000	         0.3587 ns/op	       0 B/op	       0 allocs/op
BenchmarkLoad_llxisdsh_xsync_MapOf
BenchmarkLoad_llxisdsh_xsync_MapOf-64           	1000000000	         0.2742 ns/op	       0 B/op	       0 allocs/op
BenchmarkDelete_llxisdsh_xsync_MapOf
BenchmarkDelete_llxisdsh_xsync_MapOf-64         	1000000000	         0.3363 ns/op	       0 B/op	       0 allocs/op

10000
--
BenchmarkStore_xsync_MapOf-64                   	65915614	        19.48 ns/op	      16 B/op	       1 allocs/op
BenchmarkLoadOrStore_xsync_MapOf
BenchmarkLoadOrStore_xsync_MapOf-64             	1000000000	         0.8187 ns/op	       0 B/op	       0 allocs/op
BenchmarkLoad_xsync_MapOf
BenchmarkLoad_xsync_MapOf-64                    	1000000000	         0.3003 ns/op	       0 B/op	       0 allocs/op
BenchmarkDelete_xsync_MapOf
BenchmarkDelete_xsync_MapOf-64                  	100000000	        19.43 ns/op	       0 B/op	       0 allocs/op
BenchmarkStore_llxisdsh_xsync_MapOf
BenchmarkStore_llxisdsh_xsync_MapOf-64          	71049207	        17.16 ns/op	      16 B/op	       1 allocs/op
BenchmarkLoadOrStore_llxisdsh_xsync_MapOf
BenchmarkLoadOrStore_llxisdsh_xsync_MapOf-64    	1000000000	         0.7479 ns/op	       0 B/op	       0 allocs/op
BenchmarkLoad_llxisdsh_xsync_MapOf
BenchmarkLoad_llxisdsh_xsync_MapOf-64           	1000000000	         0.3019 ns/op	       0 B/op	       0 allocs/op
BenchmarkDelete_llxisdsh_xsync_MapOf
BenchmarkDelete_llxisdsh_xsync_MapOf-64         	1000000000	         0.4552 ns/op	       0 B/op	       0 allocs/op

1000000
--
BenchmarkStore_xsync_MapOf-64                   	88764064	        12.14 ns/op	      16 B/op	       1 allocs/op
BenchmarkLoadOrStore_xsync_MapOf
BenchmarkLoadOrStore_xsync_MapOf-64             	111211852	         9.278 ns/op	       0 B/op	       0 allocs/op
BenchmarkLoad_xsync_MapOf
BenchmarkLoad_xsync_MapOf-64                    	734858245	         1.649 ns/op	       0 B/op	       0 allocs/op
BenchmarkDelete_xsync_MapOf
BenchmarkDelete_xsync_MapOf-64                  	100000000	        10.36 ns/op	       0 B/op	       0 allocs/op
BenchmarkStore_llxisdsh_xsync_MapOf
BenchmarkStore_llxisdsh_xsync_MapOf-64          	134047599	         8.224 ns/op	      16 B/op	       1 allocs/op
BenchmarkLoadOrStore_llxisdsh_xsync_MapOf
BenchmarkLoadOrStore_llxisdsh_xsync_MapOf-64    	265155219	         4.273 ns/op	       0 B/op	       0 allocs/op
BenchmarkLoad_llxisdsh_xsync_MapOf
BenchmarkLoad_llxisdsh_xsync_MapOf-64           	736806104	         1.645 ns/op	       0 B/op	       0 allocs/op
BenchmarkDelete_llxisdsh_xsync_MapOf
BenchmarkDelete_llxisdsh_xsync_MapOf-64         	1000000000	         0.8225 ns/op	       0 B/op	       0 allocs/op


1000000000
--
BenchmarkStore_xsync_MapOf-64                   	78054844	        13.08 ns/op	      16 B/op	       1 allocs/op
BenchmarkLoadOrStore_xsync_MapOf
BenchmarkLoadOrStore_xsync_MapOf-64             	77982336	        13.66 ns/op	       1 B/op	       0 allocs/op
BenchmarkLoad_xsync_MapOf
BenchmarkLoad_xsync_MapOf-64                    	737120659	         1.627 ns/op	       0 B/op	       0 allocs/op
BenchmarkDelete_xsync_MapOf
BenchmarkDelete_xsync_MapOf-64                  	100000000	        10.24 ns/op	       0 B/op	       0 allocs/op
BenchmarkStore_llxisdsh_xsync_MapOf
BenchmarkStore_llxisdsh_xsync_MapOf-64          	124132472	         9.237 ns/op	      17 B/op	       1 allocs/op
BenchmarkLoadOrStore_llxisdsh_xsync_MapOf
BenchmarkLoadOrStore_llxisdsh_xsync_MapOf-64    	121622772	         9.730 ns/op	       0 B/op	       0 allocs/op
BenchmarkLoad_llxisdsh_xsync_MapOf
BenchmarkLoad_llxisdsh_xsync_MapOf-64           	736798413	         1.620 ns/op	       0 B/op	       0 allocs/op
BenchmarkDelete_llxisdsh_xsync_MapOf
BenchmarkDelete_llxisdsh_xsync_MapOf-64         	1000000000	         0.8053 ns/op	       0 B/op	       0 allocs/op

