### PR TITLE
Parallel Incremental Resizing

### DIFF
--- a/map.go
+++ b/map.go
@@ -103,7 +103,6 @@ type Map[K comparable, V any] struct {
 	seed         maphash.Seed
 	minTableLen  int
 	growOnly     bool
-	serialResize bool
 }
 
 type resizeState[K comparable, V any] struct {
@@ -152,9 +151,8 @@ type entry[K comparable, V any] struct {
 
 // MapConfig defines configurable Map options.
 type MapConfig struct {
-	sizeHint     int
-	growOnly     bool
-	serialResize bool
+	sizeHint int
+	growOnly bool
 }
 
 // WithPresize configures new Map instance with capacity enough
@@ -183,9 +181,10 @@ func WithGrowOnly() func(*MapConfig) {
 // older versions. With this setting, Map will no longer spawn additional
 // goroutines when resizing. Use in resource-constrained environments, while
 // parallel resizing (default) provides higher throughput.
+//
+// Deprecated: Default behavior now uses only writer goroutines for resizing
 func WithSerialResize() func(*MapConfig) {
 	return func(c *MapConfig) {
-		c.serialResize = true
 	}
 }
 
@@ -216,7 +215,6 @@ func NewMap[K comparable, V any](options ...func(*MapConfig)) *Map[K, V] {
 	m.seed = maphash.MakeSeed()
 	m.minTableLen = len(table.buckets)
 	m.growOnly = c.growOnly
-	m.serialResize = c.serialResize
 	m.table.Store(table)
 	return m
 }


### PR DESCRIPTION
This PR modifies Resize to only use worker goroutines for execution, which reduces peak overhead during Resize but slightly decreases throughput when using only one goroutine. Below is a comparison with the current release version:

- Throughput (100 M insert)

| Implementation | Concurrency | Pre-Sized | Throughput (M ops/sec) |
| ------------------ | ----------- | --------- | ---------------------: |
| fork    | 1           | No        |                   3.17 |
| xsync   | 1           | No        |                   4.80 |
| fork    | 64          | No        |                  22.06 |
| xsync   | 64          | No        |                  21.99 |
| fork    | 1           | Yes       |                   5.92 |
| xsync   | 1           | Yes       |                   5.79 |
| fork    | 64          | Yes       |                  65.00 |
| xsync   | 64          | Yes       |                  65.38 |

- map_test benchmark
there's almost no change.

**Implementation approach**

The typical Resize process consists of:
Phase 1: Creating NewTable
Phase 2: Data migration

Previously, Resize would block all write operations. The current implementation allows writes to continue in the old table during Phase 1, while writes encountering Phase 2 will assist with Resize completion before writing to the new table. This design is based on:

1. Phase 1 cannot be parallelized. Allowing goroutines to continue writing to the old table improves throughput. When NewTable is very large, Phase 1 execution time becomes significantly long (far exceeding Phase 2), even warranting consideration of asynchronous allocation via a separate goroutine (implementation details are in the commit comments - your call).

2. Phase 2 can be parallelized, but determining how many buckets each writing goroutine should migrate is challenging. This implementation uses a progress bar mechanism: first dividing into segments, then having goroutines compete to migrate the next available segment until all segments are migrated. This ensures all goroutines eventually operate on the new table, maintaining consistency with previous behavior.

**Additional changes**

Moved the hash seed into the Map structure instead of regenerating it with each NewTable. This allows migration during expansion to proceed without locking target buckets (though shrinking still requires locks), improving throughput by ~10%.

**Remaining issue**

The `TestMapStoreThenParallelDelete_DoesNotShrinkBelowMinTableLen` test occasionally fails because previously Resize would always block all write operations (including deletes), ensuring thorough execution of shrink triggers. With these modifications, Resize doesn't always block, so rapid deletes may cause some shrink operations to be discarded before completion. Adding waitForResize blocking fixes the test but significantly reduces throughput, making it counterproductive (note that most Map implementations don't support automatic online shrinking anyway).

**Other**

For my [pb.Mapof](https://github.com/llxisdsh/pb) implementation, I've made these additional Resize optimizations (can submit a new PR if desired):

- Changed integer hash values to use the raw value itself (similar to Java CHM): 
  Improves throughput for sequential insertion of integer keys by **~3x**.
- Eliminated meta initialization overhead: 
  Modified SWAR algorithm to use bit 7=0 for empty slots (currently inverted, requiring 0x80 initialization). This minor code change provides **single-digit %** throughput improvement.
- Made expansion ratio dynamic based on current size (not strictly 2x): 
  Testing shows 2x suffices for most cases, with only specific allocation sizes requiring 4x jumps (minimal improvement)