### PR TITLE
Cooperative rehashing in Map

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ s := m.Size()
 
 `Map` uses a modified version of Cache-Line Hash Table (CLHT) data structure: https://github.com/LPD-EPFL/CLHT
 
-CLHT is built around the idea of organizing the hash table in cache-line-sized buckets, so that on all modern CPUs update operations complete with minimal cache-line transfer. Also, `Get` operations are obstruction-free and involve no writes to shared memory, hence no mutexes or any other sort of locks. Due to this design, in all considered scenarios `Map` outperforms `sync.Map`.
+CLHT is built around the idea of organizing the hash table in cache-line-sized buckets, so that on all modern CPUs update operations complete with minimal cache-line transfer. Also, `Get` operations are obstruction-free and involve no writes to shared memory, hence no mutexes or any other sort of locks. Due to this design, in all considered scenarios `Map` outperforms `sync.Map`. `Map` also uses cooperative parallel rehashing: this means that the goroutines executing write operations may participate in a concurrent rehashing instead of waiting for it to finish.
 
 Apart from CLHT, `Map` borrows ideas from Java's `j.u.c.ConcurrentHashMap` (immutable K/V pair structs instead of atomic snapshots) and C++'s `absl::flat_hash_map` (meta memory and SWAR-based lookups).
 

--- a/export_test.go
+++ b/export_test.go
@@ -9,7 +9,7 @@ const (
 )
 
 type (
-	BucketPadded[K comparable, V any] = bucketPadded[K, V]
+	BucketPadded = bucketPadded
 )
 
 func EnableAssertions() {

--- a/map.go
+++ b/map.go
@@ -869,7 +869,7 @@ func (m *Map[K, V]) Size() int {
 }
 
 // It is safe to use plain stores here because the destination bucket must be
-// either locked or execlusively written to by the helper during resize.
+// either locked or exclusively written to by the helper during resize.
 func appendToBucket[K comparable, V any](h2 uint8, e *entry[K, V], b *bucketPadded) {
 	for {
 		for i := 0; i < entriesPerMapBucket; i++ {

--- a/map.go
+++ b/map.go
@@ -668,7 +668,7 @@ func (m *Map[K, V]) resize(knownTable *mapTable[K, V], hint mapResizeHint) {
 	// Copy the data only if we're not clearing the map.
 	if hint != mapClearHint {
 		// Set up cooperative transfer state.
-		// Initialization order matters here
+		// Next table must be published as the last step.
 		m.resizeIdx.Store(0)
 		m.nextTable.Store(newTable)
 		// Copy the buckets.

--- a/map.go
+++ b/map.go
@@ -722,8 +722,7 @@ func (m *Map[K, V]) transfer(table, newTable *mapTable[K, V]) {
 	}
 }
 
-// TODO: it's fine to use plain stores here
-// doesn't acquire dest bucket lock
+// Doesn't acquire dest bucket lock.
 func transferBucketUnsafe[K comparable, V any](
 	b *bucketPadded,
 	destTable *mapTable[K, V],
@@ -834,6 +833,8 @@ func (m *Map[K, V]) Size() int {
 	return int(m.table.Load().sumSize())
 }
 
+// It is safe to use plain stores here because the destination bucket must be
+// either locked or execlusively written to by the helper during resize.
 func appendToBucket[K comparable, V any](h2 uint8, e *entry[K, V], b *bucketPadded) {
 	for {
 		for i := 0; i < entriesPerMapBucket; i++ {

--- a/map.go
+++ b/map.go
@@ -671,7 +671,7 @@ func (m *Map[K, V]) helpResize(seq int64) {
 		table := m.table.Load()
 		nextTable := m.nextTable.Load()
 		if m.resizeSeq.Load() == seq {
-			if nextTable == nil {
+			if nextTable == nil || nextTable == table {
 				// Carry on until the next table is set by the main
 				// resize goroutine or until the resize finishes.
 				runtime.Gosched()

--- a/map_test.go
+++ b/map_test.go
@@ -856,7 +856,7 @@ func testParallelResize(t *testing.T, numGoroutines int) {
 	}
 }
 
-func TestParallelResize(t *testing.T) {
+func TestMapParallelResize(t *testing.T) {
 	testParallelResize(t, 1)
 	testParallelResize(t, runtime.GOMAXPROCS(0))
 	testParallelResize(t, 100)
@@ -900,7 +900,7 @@ func testParallelResizeWithSameKeys(t *testing.T, numGoroutines int) {
 	}
 }
 
-func TestParallelResize_IntersectingKeys(t *testing.T) {
+func TestMapParallelResize_IntersectingKeys(t *testing.T) {
 	testParallelResizeWithSameKeys(t, 1)
 	testParallelResizeWithSameKeys(t, runtime.GOMAXPROCS(0))
 	testParallelResizeWithSameKeys(t, 100)
@@ -943,7 +943,7 @@ func testParallelShrinking(t *testing.T, numGoroutines int) {
 	}
 }
 
-func TestParallelShrinking(t *testing.T) {
+func TestMapParallelShrinking(t *testing.T) {
 	testParallelShrinking(t, 1)
 	testParallelShrinking(t, runtime.GOMAXPROCS(0))
 	testParallelShrinking(t, 100)

--- a/map_test.go
+++ b/map_test.go
@@ -54,11 +54,11 @@ func runParallel(b *testing.B, benchFn func(pb *testing.PB)) {
 }
 
 func TestMap_BucketStructSize(t *testing.T) {
-	size := unsafe.Sizeof(BucketPadded[string, int64]{})
+	size := unsafe.Sizeof(BucketPadded{})
 	if size != 64 {
 		t.Fatalf("size of 64B (one cache line) is expected, got: %d", size)
 	}
-	size = unsafe.Sizeof(BucketPadded[struct{}, int32]{})
+	size = unsafe.Sizeof(BucketPadded{})
 	if size != 64 {
 		t.Fatalf("size of 64B (one cache line) is expected, got: %d", size)
 	}

--- a/util.go
+++ b/util.go
@@ -60,6 +60,7 @@ func markZeroBytes(w uint64) uint64 {
 	return ((w - 0x0101010101010101) & (^w) & 0x8080808080808080)
 }
 
+// Sets byte of the input word at the specified index to the given value.
 func setByte(w uint64, b uint8, idx int) uint64 {
 	shift := idx << 3
 	return (w &^ (0xff << shift)) | (uint64(b) << shift)


### PR DESCRIPTION
Introduces cooperative rehashing for `xsync.Map` this means that goroutines that execute write operations, such as `Compute` or `Store`, may participate in table rehashing when the hash table grows or shrinks.

This behavior is always enabled, so the `WithSerialResize` function now acts as a no-op and is marked as deprecated.

### Microbenchmarks

This patch:
```
BenchmarkMapParallelRehashing/1goroutine_10M-24         	       1	2133256824 ns/op	   4775648 entries/s	754307064 B/op	10895782 allocs/op
BenchmarkMapParallelRehashing/4goroutines_10M-24        	       2	 695167535 ns/op	  14953777 entries/s	754273520 B/op	10896557 allocs/op
BenchmarkMapParallelRehashing/8goroutines_10M-24        	       2	 530385413 ns/op	  20218249 entries/s	754222912 B/op	10895744 allocs/o
```

`main` (shows similar performance, but it spawns additional goroutines):
```
BenchmarkMapParallelRehashing/1goroutine_10M-24         	       1	1618531417 ns/op	   6353257 entries/s	754494144 B/op	10897257 allocs/op
BenchmarkMapParallelRehashing/4goroutines_10M-24        	       2	 686399372 ns/op	  15111888 entries/s	754325640 B/op	10896794 allocs/op
BenchmarkMapParallelRehashing/8goroutines_10M-24        	       2	 580604480 ns/op	  18540992 entries/s	754368512 B/op	10897750 allocs/op
```

`main` with `WithSerialResize` (slowest results):
```
BenchmarkMapParallelRehashing/1goroutine_10M-24         	       1	2714459878 ns/op	   3746302 entries/s	754247408 B/op	10894942 allocs/op
BenchmarkMapParallelRehashing/4goroutines_10M-24        	       1	1838145032 ns/op	   5574501 entries/s	754255576 B/op	10896288 allocs/op
BenchmarkMapParallelRehashing/8goroutines_10M-24        	       1	1792728777 ns/op	   5720168 entries/s	754248344 B/op	10896154 allocs/op
```