### PR TITLE
chore: modernize for go 1.24

### DIFF
--- a/counter_test.go
+++ b/counter_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestCounterInc(t *testing.T) {
 	c := NewCounter()
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		if v := c.Value(); v != int64(i) {
 			t.Fatalf("got %v, want %d", v, i)
 		}
@@ -20,7 +20,7 @@ func TestCounterInc(t *testing.T) {
 
 func TestCounterDec(t *testing.T) {
 	c := NewCounter()
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		if v := c.Value(); v != int64(-i) {
 			t.Fatalf("got %v, want %d", v, -i)
 		}
@@ -30,7 +30,7 @@ func TestCounterDec(t *testing.T) {
 
 func TestCounterAdd(t *testing.T) {
 	c := NewCounter()
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		if v := c.Value(); v != int64(i*42) {
 			t.Fatalf("got %v, want %d", v, i*42)
 		}
@@ -51,7 +51,7 @@ func TestCounterReset(t *testing.T) {
 }
 
 func parallelIncrementor(c *Counter, numIncs int, cdone chan bool) {
-	for i := 0; i < numIncs; i++ {
+	for range numIncs {
 		c.Inc()
 	}
 	cdone <- true
@@ -62,11 +62,11 @@ func doTestParallelIncrementors(t *testing.T, numModifiers, gomaxprocs int) {
 	c := NewCounter()
 	cdone := make(chan bool)
 	numIncs := 10_000
-	for i := 0; i < numModifiers; i++ {
+	for range numModifiers {
 		go parallelIncrementor(c, numIncs, cdone)
 	}
 	// Wait for the goroutines to finish.
-	for i := 0; i < numModifiers; i++ {
+	for range numModifiers {
 		<-cdone
 	}
 	expected := int64(numModifiers * numIncs)

--- a/map.go
+++ b/map.go
@@ -771,7 +771,7 @@ func transferBucketUnsafe[K comparable, V any](
 	rootb := b
 	rootb.mu.Lock()
 	for {
-		for i := 0; i < entriesPerMapBucket; i++ {
+		for i := range entriesPerMapBucket {
 			if eptr := b.entries[i]; eptr != nil {
 				e := (*entry[K, V])(eptr)
 				hash := maphash.Comparable(destTable.seed, e.key)
@@ -796,7 +796,7 @@ func transferBucket[K comparable, V any](
 	rootb := b
 	rootb.mu.Lock()
 	for {
-		for i := 0; i < entriesPerMapBucket; i++ {
+		for i := range entriesPerMapBucket {
 			if eptr := b.entries[i]; eptr != nil {
 				e := (*entry[K, V])(eptr)
 				hash := maphash.Comparable(destTable.seed, e.key)
@@ -840,7 +840,7 @@ func (m *Map[K, V]) Range(f func(key K, value V) bool) {
 		// the intermediate slice.
 		rootb.mu.Lock()
 		for {
-			for i := 0; i < entriesPerMapBucket; i++ {
+			for i := range entriesPerMapBucket {
 				if b.entries[i] != nil {
 					bentries = append(bentries, (*entry[K, V])(b.entries[i]))
 				}
@@ -878,7 +878,7 @@ func (m *Map[K, V]) Size() int {
 // either locked or exclusively written to by the helper during resize.
 func appendToBucket[K comparable, V any](h2 uint8, e *entry[K, V], b *bucketPadded) {
 	for {
-		for i := 0; i < entriesPerMapBucket; i++ {
+		for i := range entriesPerMapBucket {
 			if b.entries[i] == nil {
 				b.meta = setByte(b.meta, h2, i)
 				b.entries[i] = unsafe.Pointer(e)
@@ -997,7 +997,7 @@ func (m *Map[K, V]) Stats() MapStats {
 		for {
 			nentriesLocal := 0
 			stats.Capacity += entriesPerMapBucket
-			for i := 0; i < entriesPerMapBucket; i++ {
+			for i := range entriesPerMapBucket {
 				if atomic.LoadPointer(&b.entries[i]) != nil {
 					stats.Size++
 					nentriesLocal++

--- a/map_test.go
+++ b/map_test.go
@@ -40,7 +40,7 @@ var benchmarkKeys []string
 
 func init() {
 	benchmarkKeys = make([]string, benchmarkNumEntries)
-	for i := 0; i < benchmarkNumEntries; i++ {
+	for i := range benchmarkNumEntries {
 		benchmarkKeys[i] = benchmarkKeyPrefix + strconv.Itoa(i)
 	}
 }
@@ -184,7 +184,7 @@ func TestMapLoadAndStore_NonNilValue(t *testing.T) {
 func TestMapRange(t *testing.T) {
 	const numEntries = 1000
 	m := NewMap[string, int]()
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		m.Store(strconv.Itoa(i), i)
 	}
 	iters := 0
@@ -201,7 +201,7 @@ func TestMapRange(t *testing.T) {
 	if iters != numEntries {
 		t.Fatalf("got unexpected number of iterations: %d", iters)
 	}
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		if c := met[strconv.Itoa(i)]; c != 1 {
 			t.Fatalf("range did not iterate correctly over %d: %d", i, c)
 		}
@@ -210,7 +210,7 @@ func TestMapRange(t *testing.T) {
 
 func TestMapRange_FalseReturned(t *testing.T) {
 	m := NewMap[string, int]()
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		m.Store(strconv.Itoa(i), i)
 	}
 	iters := 0
@@ -226,14 +226,14 @@ func TestMapRange_FalseReturned(t *testing.T) {
 func TestMapRange_NestedDelete(t *testing.T) {
 	const numEntries = 256
 	m := NewMap[string, int]()
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		m.Store(strconv.Itoa(i), i)
 	}
 	m.Range(func(key string, value int) bool {
 		m.Delete(key)
 		return true
 	})
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		if _, ok := m.Load(strconv.Itoa(i)); ok {
 			t.Fatalf("value found for %d", i)
 		}
@@ -243,10 +243,10 @@ func TestMapRange_NestedDelete(t *testing.T) {
 func TestMapStringStore(t *testing.T) {
 	const numEntries = 128
 	m := NewMap[string, int]()
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		m.Store(strconv.Itoa(i), i)
 	}
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		v, ok := m.Load(strconv.Itoa(i))
 		if !ok {
 			t.Fatalf("value not found for %d", i)
@@ -260,10 +260,10 @@ func TestMapStringStore(t *testing.T) {
 func TestMapIntStore(t *testing.T) {
 	const numEntries = 128
 	m := NewMap[int, int]()
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		m.Store(i, i)
 	}
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		v, ok := m.Load(i)
 		if !ok {
 			t.Fatalf("value not found for %d", i)
@@ -277,10 +277,10 @@ func TestMapIntStore(t *testing.T) {
 func TestMapStore_StructKeys_IntValues(t *testing.T) {
 	const numEntries = 128
 	m := NewMap[point, int]()
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		m.Store(point{int32(i), -int32(i)}, i)
 	}
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		v, ok := m.Load(point{int32(i), -int32(i)})
 		if !ok {
 			t.Fatalf("value not found for %d", i)
@@ -294,10 +294,10 @@ func TestMapStore_StructKeys_IntValues(t *testing.T) {
 func TestMapStore_StructKeys_StructValues(t *testing.T) {
 	const numEntries = 128
 	m := NewMap[point, point]()
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		m.Store(point{int32(i), -int32(i)}, point{-int32(i), int32(i)})
 	}
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		v, ok := m.Load(point{int32(i), -int32(i)})
 		if !ok {
 			t.Fatalf("value not found for %d", i)
@@ -314,10 +314,10 @@ func TestMapStore_StructKeys_StructValues(t *testing.T) {
 func TestMapLoadOrStore(t *testing.T) {
 	const numEntries = 1000
 	m := NewMap[string, int]()
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		m.Store(strconv.Itoa(i), i)
 	}
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		if _, loaded := m.LoadOrStore(strconv.Itoa(i), i); !loaded {
 			t.Fatalf("value not found for %d", i)
 		}
@@ -327,7 +327,7 @@ func TestMapLoadOrStore(t *testing.T) {
 func TestMapLoadOrCompute(t *testing.T) {
 	const numEntries = 1000
 	m := NewMap[string, int]()
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		v, loaded := m.LoadOrCompute(strconv.Itoa(i), func() (newValue int, cancel bool) {
 			return i, true
 		})
@@ -341,7 +341,7 @@ func TestMapLoadOrCompute(t *testing.T) {
 	if m.Size() != 0 {
 		t.Fatalf("zero map size expected: %d", m.Size())
 	}
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		v, loaded := m.LoadOrCompute(strconv.Itoa(i), func() (newValue int, cancel bool) {
 			return i, false
 		})
@@ -352,7 +352,7 @@ func TestMapLoadOrCompute(t *testing.T) {
 			t.Fatalf("values do not match for %d: %v", i, v)
 		}
 	}
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		v, loaded := m.LoadOrCompute(strconv.Itoa(i), func() (newValue int, cancel bool) {
 			t.Fatalf("value func invoked")
 			return newValue, false
@@ -490,10 +490,10 @@ func TestMapOfCompute(t *testing.T) {
 func TestMapStringStoreThenDelete(t *testing.T) {
 	const numEntries = 1000
 	m := NewMap[string, int]()
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		m.Store(strconv.Itoa(i), i)
 	}
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		m.Delete(strconv.Itoa(i))
 		if _, ok := m.Load(strconv.Itoa(i)); ok {
 			t.Fatalf("value was not expected for %d", i)
@@ -504,10 +504,10 @@ func TestMapStringStoreThenDelete(t *testing.T) {
 func TestMapIntStoreThenDelete(t *testing.T) {
 	const numEntries = 1000
 	m := NewMap[int32, int32]()
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		m.Store(int32(i), int32(i))
 	}
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		m.Delete(int32(i))
 		if _, ok := m.Load(int32(i)); ok {
 			t.Fatalf("value was not expected for %d", i)
@@ -518,10 +518,10 @@ func TestMapIntStoreThenDelete(t *testing.T) {
 func TestMapStructStoreThenDelete(t *testing.T) {
 	const numEntries = 1000
 	m := NewMap[point, string]()
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		m.Store(point{int32(i), 42}, strconv.Itoa(i))
 	}
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		m.Delete(point{int32(i), 42})
 		if _, ok := m.Load(point{int32(i), 42}); ok {
 			t.Fatalf("value was not expected for %d", i)
@@ -532,10 +532,10 @@ func TestMapStructStoreThenDelete(t *testing.T) {
 func TestMapStringStoreThenLoadAndDelete(t *testing.T) {
 	const numEntries = 1000
 	m := NewMap[string, int]()
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		m.Store(strconv.Itoa(i), i)
 	}
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		if v, loaded := m.LoadAndDelete(strconv.Itoa(i)); !loaded || v != i {
 			t.Fatalf("value was not found or different for %d: %v", i, v)
 		}
@@ -548,10 +548,10 @@ func TestMapStringStoreThenLoadAndDelete(t *testing.T) {
 func TestMapIntStoreThenLoadAndDelete(t *testing.T) {
 	const numEntries = 1000
 	m := NewMap[int, int]()
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		m.Store(i, i)
 	}
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		if _, loaded := m.LoadAndDelete(i); !loaded {
 			t.Fatalf("value was not found for %d", i)
 		}
@@ -564,10 +564,10 @@ func TestMapIntStoreThenLoadAndDelete(t *testing.T) {
 func TestMapStructStoreThenLoadAndDelete(t *testing.T) {
 	const numEntries = 1000
 	m := NewMap[point, int]()
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		m.Store(point{42, int32(i)}, i)
 	}
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		if _, loaded := m.LoadAndDelete(point{42, int32(i)}); !loaded {
 			t.Fatalf("value was not found for %d", i)
 		}
@@ -580,19 +580,19 @@ func TestMapStructStoreThenLoadAndDelete(t *testing.T) {
 func TestMapStoreThenParallelDelete_DoesNotShrinkBelowMinTableLen(t *testing.T) {
 	const numEntries = 1000
 	m := NewMap[int, int]()
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		m.Store(i, i)
 	}
 
 	cdone := make(chan bool)
 	go func() {
-		for i := 0; i < numEntries; i++ {
+		for i := range numEntries {
 			m.Delete(i)
 		}
 		cdone <- true
 	}()
 	go func() {
-		for i := 0; i < numEntries; i++ {
+		for i := range numEntries {
 			m.Delete(i)
 		}
 		cdone <- true
@@ -625,7 +625,7 @@ func TestMapSize(t *testing.T) {
 		t.Fatalf("zero size expected: %d", size)
 	}
 	expectedSize := 0
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		m.Store(strconv.Itoa(i), i)
 		expectedSize++
 		size := m.Size()
@@ -637,7 +637,7 @@ func TestMapSize(t *testing.T) {
 			t.Fatalf("size does not match number of entries in Range: %v, %v", size, rsize)
 		}
 	}
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		m.Delete(strconv.Itoa(i))
 		expectedSize--
 		size := m.Size()
@@ -654,7 +654,7 @@ func TestMapSize(t *testing.T) {
 func TestMapClear(t *testing.T) {
 	const numEntries = 1000
 	m := NewMap[string, int]()
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		m.Store(strconv.Itoa(i), i)
 	}
 	size := m.Size()
@@ -692,7 +692,7 @@ func TestNewMapWithPresize_DoesNotShrinkBelowMinTableLen(t *testing.T) {
 	const minTableLen = 1024
 	const numEntries = int(minTableLen * EntriesPerMapBucket * MapLoadFactor)
 	m := NewMap[int, int](WithPresize(numEntries))
-	for i := 0; i < 2*numEntries; i++ {
+	for i := range 2 * numEntries {
 		m.Store(i, i)
 	}
 
@@ -701,7 +701,7 @@ func TestNewMapWithPresize_DoesNotShrinkBelowMinTableLen(t *testing.T) {
 		t.Fatalf("table did not grow: %d", stats.RootBuckets)
 	}
 
-	for i := 0; i < 2*numEntries; i++ {
+	for i := range 2 * numEntries {
 		m.Delete(i)
 	}
 
@@ -719,7 +719,7 @@ func TestNewMapGrowOnly_OnlyShrinksOnClear(t *testing.T) {
 	stats := m.Stats()
 	initialTableLen := stats.RootBuckets
 
-	for i := 0; i < 2*numEntries; i++ {
+	for i := range 2 * numEntries {
 		m.Store(i, i)
 	}
 	stats = m.Stats()
@@ -728,7 +728,7 @@ func TestNewMapGrowOnly_OnlyShrinksOnClear(t *testing.T) {
 		t.Fatalf("table did not grow: %d", maxTableLen)
 	}
 
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		m.Delete(i)
 	}
 	stats = m.Stats()
@@ -747,7 +747,7 @@ func TestMapResize(t *testing.T) {
 	m := NewMap[string, int]()
 	const numEntries = 100_000
 
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		m.Store(strconv.Itoa(i), i)
 	}
 	stats := m.Stats()
@@ -771,7 +771,7 @@ func TestMapResize(t *testing.T) {
 	// Use -v flag to see the output.
 	t.Log(stats.ToString())
 
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		m.Delete(strconv.Itoa(i))
 	}
 	stats = m.Stats()
@@ -795,7 +795,7 @@ func TestMapResize_CounterLenLimit(t *testing.T) {
 	const numEntries = 1_000_000
 	m := NewMap[string, string]()
 
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		m.Store("foo"+strconv.Itoa(i), "bar"+strconv.Itoa(i))
 	}
 	stats := m.Stats()
@@ -814,7 +814,7 @@ func testParallelResize(t *testing.T, numGoroutines int) {
 	// Fill the map to trigger resizing
 	const initialEntries = 10000
 	const newEntries = 5000
-	for i := 0; i < initialEntries; i++ {
+	for i := range initialEntries {
 		m.Store(i, i*2)
 	}
 
@@ -822,13 +822,13 @@ func testParallelResize(t *testing.T, numGoroutines int) {
 	var wg sync.WaitGroup
 
 	// Launch goroutines that will encounter resize operations
-	for g := 0; g < numGoroutines; g++ {
+	for g := range numGoroutines {
 		wg.Add(1)
 		go func(goroutineID int) {
 			defer wg.Done()
 
 			// Perform many operations to trigger resize and helping
-			for i := 0; i < newEntries; i++ {
+			for i := range newEntries {
 				key := goroutineID*newEntries + i + initialEntries
 				m.Store(key, key*2)
 
@@ -867,7 +867,7 @@ func testParallelResizeWithSameKeys(t *testing.T, numGoroutines int) {
 
 	// Fill the map to trigger resizing
 	const entries = 1000
-	for i := 0; i < entries; i++ {
+	for i := range entries {
 		m.Store(2*i, 2*i)
 	}
 
@@ -875,11 +875,11 @@ func testParallelResizeWithSameKeys(t *testing.T, numGoroutines int) {
 	var wg sync.WaitGroup
 
 	// Launch goroutines that will encounter resize operations
-	for g := 0; g < numGoroutines; g++ {
+	for g := range numGoroutines {
 		wg.Add(1)
 		go func(goroutineID int) {
 			defer wg.Done()
-			for i := 0; i < 10*entries; i++ {
+			for i := range 10 * entries {
 				m.Store(i, i)
 			}
 		}(g)
@@ -911,7 +911,7 @@ func testParallelShrinking(t *testing.T, numGoroutines int) {
 
 	// Fill the map to trigger resizing
 	const entries = 100000
-	for i := 0; i < entries; i++ {
+	for i := range entries {
 		m.Store(i, i)
 	}
 
@@ -919,11 +919,11 @@ func testParallelShrinking(t *testing.T, numGoroutines int) {
 	var wg sync.WaitGroup
 
 	// Launch goroutines that will encounter resize operations
-	for g := 0; g < numGoroutines; g++ {
+	for g := range numGoroutines {
 		wg.Add(1)
 		go func(goroutineID int) {
 			defer wg.Done()
-			for i := 0; i < entries; i++ {
+			for i := range entries {
 				m.Delete(i)
 			}
 		}(g)
@@ -950,7 +950,7 @@ func TestMapParallelShrinking(t *testing.T) {
 }
 
 func parallelSeqMapGrower(m *Map[int, int], numEntries int, positive bool, cdone chan bool) {
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		if positive {
 			m.Store(i, i)
 		} else {
@@ -986,9 +986,9 @@ func TestMapParallelGrowth_GrowOnly(t *testing.T) {
 
 func parallelRandMapResizer(t *testing.T, m *Map[string, int], numIters, numEntries int, cdone chan bool) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	for i := 0; i < numIters; i++ {
+	for range numIters {
 		coin := r.Int63n(2)
-		for j := 0; j < numEntries; j++ {
+		for j := range numEntries {
 			if coin == 1 {
 				m.Store(strconv.Itoa(j), j)
 			} else {
@@ -1010,7 +1010,7 @@ func TestMapParallelGrowth(t *testing.T) {
 	<-cdone
 	<-cdone
 	// Verify map contents.
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		v, ok := m.Load(strconv.Itoa(i))
 		if !ok {
 			// The entry may be deleted and that's ok.
@@ -1032,9 +1032,9 @@ func TestMapParallelGrowth(t *testing.T) {
 
 func parallelRandMapClearer(t *testing.T, m *Map[string, int], numIters, numEntries int, cdone chan bool) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	for i := 0; i < numIters; i++ {
+	for range numIters {
 		coin := r.Int63n(2)
-		for j := 0; j < numEntries; j++ {
+		for j := range numEntries {
 			if coin == 1 {
 				m.Store(strconv.Itoa(j), j)
 			} else {
@@ -1067,8 +1067,8 @@ func TestMapParallelClear(t *testing.T) {
 }
 
 func parallelSeqMapStorer(t *testing.T, m *Map[string, int], storeEach, numIters, numEntries int, cdone chan bool) {
-	for i := 0; i < numIters; i++ {
-		for j := 0; j < numEntries; j++ {
+	for range numIters {
+		for j := range numEntries {
 			if storeEach == 0 || j%storeEach == 0 {
 				m.Store(strconv.Itoa(j), j)
 				// Due to atomic snapshots we must see a "<j>"/j pair.
@@ -1093,15 +1093,15 @@ func TestMapParallelStores(t *testing.T) {
 	const numEntries = 100
 	m := NewMap[string, int]()
 	cdone := make(chan bool)
-	for i := 0; i < numStorers; i++ {
+	for i := range numStorers {
 		go parallelSeqMapStorer(t, m, i, numIters, numEntries, cdone)
 	}
 	// Wait for the goroutines to finish.
-	for i := 0; i < numStorers; i++ {
+	for range numStorers {
 		<-cdone
 	}
 	// Verify map contents.
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		v, ok := m.Load(strconv.Itoa(i))
 		if !ok {
 			t.Fatalf("value not found for %d", i)
@@ -1114,7 +1114,7 @@ func TestMapParallelStores(t *testing.T) {
 
 func parallelRandMapStorer(t *testing.T, m *Map[string, int], numIters, numEntries int, cdone chan bool) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	for i := 0; i < numIters; i++ {
+	for range numIters {
 		j := r.Intn(numEntries)
 		if v, loaded := m.LoadOrStore(strconv.Itoa(j), j); loaded {
 			if v != j {
@@ -1127,7 +1127,7 @@ func parallelRandMapStorer(t *testing.T, m *Map[string, int], numIters, numEntri
 
 func parallelRandMapDeleter(t *testing.T, m *Map[string, int], numIters, numEntries int, cdone chan bool) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	for i := 0; i < numIters; i++ {
+	for range numIters {
 		j := r.Intn(numEntries)
 		if v, loaded := m.LoadAndDelete(strconv.Itoa(j)); loaded {
 			if v != j {
@@ -1139,8 +1139,8 @@ func parallelRandMapDeleter(t *testing.T, m *Map[string, int], numIters, numEntr
 }
 
 func parallelMapLoader(t *testing.T, m *Map[string, int], numIters, numEntries int, cdone chan bool) {
-	for i := 0; i < numIters; i++ {
-		for j := 0; j < numEntries; j++ {
+	for range numIters {
+		for j := range numEntries {
 			// Due to atomic snapshots we must either see no entry, or a "<j>"/j pair.
 			if v, ok := m.Load(strconv.Itoa(j)); ok {
 				if v != j {
@@ -1162,7 +1162,7 @@ func TestMapAtomicSnapshot(t *testing.T) {
 	go parallelRandMapDeleter(t, m, numIters, numEntries, cdone)
 	go parallelMapLoader(t, m, numIters, numEntries, cdone)
 	// Wait for the goroutines to finish.
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		<-cdone
 	}
 }
@@ -1174,19 +1174,19 @@ func TestMapParallelStoresAndDeletes(t *testing.T) {
 	m := NewMap[string, int]()
 	cdone := make(chan bool)
 	// Update random entry in parallel with deletes.
-	for i := 0; i < numWorkers; i++ {
+	for range numWorkers {
 		go parallelRandMapStorer(t, m, numIters, numEntries, cdone)
 		go parallelRandMapDeleter(t, m, numIters, numEntries, cdone)
 	}
 	// Wait for the goroutines to finish.
-	for i := 0; i < 2*numWorkers; i++ {
+	for range 2 * numWorkers {
 		<-cdone
 	}
 }
 
 func parallelMapComputer(m *Map[uint64, uint64], numIters, numEntries int, cdone chan bool) {
-	for i := 0; i < numIters; i++ {
-		for j := 0; j < numEntries; j++ {
+	for range numIters {
+		for j := range numEntries {
 			m.Compute(uint64(j), func(oldValue uint64, loaded bool) (newValue uint64, op ComputeOp) {
 				return oldValue + 1, UpdateOp
 			})
@@ -1200,15 +1200,15 @@ func TestMapParallelComputes(t *testing.T) {
 	const numIters = 10_000
 	m := NewMap[uint64, uint64]()
 	cdone := make(chan bool)
-	for i := 0; i < numWorkers; i++ {
+	for range numWorkers {
 		go parallelMapComputer(m, numIters, numWorkers, cdone)
 	}
 	// Wait for the goroutines to finish.
-	for i := 0; i < numWorkers; i++ {
+	for range numWorkers {
 		<-cdone
 	}
 	// Verify map contents.
-	for i := 0; i < numWorkers; i++ {
+	for i := range numWorkers {
 		v, ok := m.Load(uint64(i))
 		if !ok {
 			t.Fatalf("value not found for %d", i)
@@ -1221,7 +1221,7 @@ func TestMapParallelComputes(t *testing.T) {
 
 func parallelRangeMapStorer(m *Map[int, int], numEntries int, stopFlag *int64, cdone chan bool) {
 	for {
-		for i := 0; i < numEntries; i++ {
+		for i := range numEntries {
 			m.Store(i, i)
 		}
 		if atomic.LoadInt64(stopFlag) != 0 {
@@ -1233,7 +1233,7 @@ func parallelRangeMapStorer(m *Map[int, int], numEntries int, stopFlag *int64, c
 
 func parallelRangeMapDeleter(m *Map[int, int], numEntries int, stopFlag *int64, cdone chan bool) {
 	for {
-		for i := 0; i < numEntries; i++ {
+		for i := range numEntries {
 			m.Delete(i)
 		}
 		if atomic.LoadInt64(stopFlag) != 0 {
@@ -1246,7 +1246,7 @@ func parallelRangeMapDeleter(m *Map[int, int], numEntries int, stopFlag *int64, 
 func TestMapParallelRange(t *testing.T) {
 	const numEntries = 10_000
 	m := NewMap[int, int](WithPresize(numEntries))
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		m.Store(i, i)
 	}
 	// Start goroutines that would be storing and deleting items in parallel.
@@ -1279,13 +1279,13 @@ func TestMapParallelRange(t *testing.T) {
 }
 
 func parallelMapShrinker(t *testing.T, m *Map[uint64, *point], numIters, numEntries int, stopFlag *int64, cdone chan bool) {
-	for i := 0; i < numIters; i++ {
-		for j := 0; j < numEntries; j++ {
+	for range numIters {
+		for j := range numEntries {
 			if p, loaded := m.LoadOrStore(uint64(j), &point{int32(j), int32(j)}); loaded {
 				t.Errorf("value was present for %d: %v", j, p)
 			}
 		}
-		for j := 0; j < numEntries; j++ {
+		for j := range numEntries {
 			m.Delete(uint64(j))
 		}
 	}
@@ -1351,7 +1351,7 @@ func TestMapStats(t *testing.T) {
 		t.Fatalf("unexpected counter length: %d", stats.CounterLen)
 	}
 
-	for i := 0; i < 200; i++ {
+	for i := range 200 {
 		m.Store(i, i)
 	}
 
@@ -1389,14 +1389,14 @@ func TestToPlainMap_NilPointer(t *testing.T) {
 func TestToPlainMap(t *testing.T) {
 	const numEntries = 1000
 	m := NewMap[int, int]()
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		m.Store(i, i)
 	}
 	pm := ToPlainMap[int, int](m)
 	if len(pm) != numEntries {
 		t.Fatalf("got unexpected size of nil map copy: %d", len(pm))
 	}
-	for i := 0; i < numEntries; i++ {
+	for i := range numEntries {
 		if v := pm[i]; v != i {
 			t.Fatalf("unexpected value for key %d: %d", i, v)
 		}
@@ -1426,7 +1426,7 @@ func BenchmarkMap_WarmUp(b *testing.B) {
 	for _, bc := range benchmarkCases {
 		b.Run(bc.name, func(b *testing.B) {
 			m := NewMap[string, int](WithPresize(benchmarkNumEntries))
-			for i := 0; i < benchmarkNumEntries; i++ {
+			for i := range benchmarkNumEntries {
 				m.Store(benchmarkKeyPrefix+strconv.Itoa(i), i)
 			}
 			b.ResetTimer()
@@ -1489,7 +1489,7 @@ func BenchmarkMapInt_WarmUp(b *testing.B) {
 	for _, bc := range benchmarkCases {
 		b.Run(bc.name, func(b *testing.B) {
 			m := NewMap[int, int](WithPresize(benchmarkNumEntries))
-			for i := 0; i < benchmarkNumEntries; i++ {
+			for i := range benchmarkNumEntries {
 				m.Store(i, i)
 			}
 			b.ResetTimer()
@@ -1534,7 +1534,7 @@ func BenchmarkIntMapStandard_WarmUp(b *testing.B) {
 	for _, bc := range benchmarkCases {
 		b.Run(bc.name, func(b *testing.B) {
 			var m sync.Map
-			for i := 0; i < benchmarkNumEntries; i++ {
+			for i := range benchmarkNumEntries {
 				m.Store(i, i)
 			}
 			b.ResetTimer()
@@ -1581,7 +1581,7 @@ func benchmarkMapIntKeys(
 
 func BenchmarkMapRange(b *testing.B) {
 	m := NewMap[string, int](WithPresize(benchmarkNumEntries))
-	for i := 0; i < benchmarkNumEntries; i++ {
+	for i := range benchmarkNumEntries {
 		m.Store(benchmarkKeys[i], i)
 	}
 	b.ResetTimer()
@@ -1637,7 +1637,7 @@ func BenchmarkMapParallelRehashing(b *testing.B) {
 	}
 	for _, test := range tests {
 		b.Run(test.name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				m := NewMap[int, int]()
 
 				var wg sync.WaitGroup
@@ -1650,7 +1650,7 @@ func BenchmarkMapParallelRehashing(b *testing.B) {
 					go func(goroutineID int) {
 						defer wg.Done()
 						base := goroutineID * entriesPerGoroutine
-						for j := 0; j < entriesPerGoroutine; j++ {
+						for j := range entriesPerGoroutine {
 							key := base + j
 							m.Store(key, key)
 						}

--- a/mpmcqueue_test.go
+++ b/mpmcqueue_test.go
@@ -22,12 +22,12 @@ func TestMPMCQueue_InvalidSize(t *testing.T) {
 
 func TestMPMCQueueEnqueueDequeueInt(t *testing.T) {
 	q := NewMPMCQueue[int](10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if !q.TryEnqueue(i) {
 			t.Fatalf("failed to enqueue for %d", i)
 		}
 	}
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if got, ok := q.TryDequeue(); !ok || got != i {
 			t.Fatalf("%v got %v, want %d", ok, got, i)
 		}
@@ -36,12 +36,12 @@ func TestMPMCQueueEnqueueDequeueInt(t *testing.T) {
 
 func TestMPMCQueueEnqueueDequeueString(t *testing.T) {
 	q := NewMPMCQueue[string](10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if !q.TryEnqueue(strconv.Itoa(i)) {
 			t.Fatalf("failed to enqueue for %d", i)
 		}
 	}
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if got, ok := q.TryDequeue(); !ok || got != strconv.Itoa(i) {
 			t.Fatalf("%v got %v, want %d", ok, got, i)
 		}
@@ -54,12 +54,12 @@ func TestMPMCQueueEnqueueDequeueStruct(t *testing.T) {
 		baz int
 	}
 	q := NewMPMCQueue[foo](10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if !q.TryEnqueue(foo{i, i}) {
 			t.Fatalf("failed to enqueue for %d", i)
 		}
 	}
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if got, ok := q.TryDequeue(); !ok || got.bar != i || got.baz != i {
 			t.Fatalf("%v got %v, want %d", ok, got, i)
 		}
@@ -72,7 +72,7 @@ func TestMPMCQueueEnqueueDequeueStructRef(t *testing.T) {
 		baz int
 	}
 	q := NewMPMCQueue[*foo](11)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if !q.TryEnqueue(&foo{i, i}) {
 			t.Fatalf("failed to enqueue for %d", i)
 		}
@@ -80,7 +80,7 @@ func TestMPMCQueueEnqueueDequeueStructRef(t *testing.T) {
 	if !q.TryEnqueue(nil) {
 		t.Fatal("failed to enqueue for nil")
 	}
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if got, ok := q.TryDequeue(); !ok || got.bar != i || got.baz != i {
 			t.Fatalf("%v got %v, want %d", ok, got, i)
 		}
@@ -92,12 +92,12 @@ func TestMPMCQueueEnqueueDequeueStructRef(t *testing.T) {
 
 func TestMPMCQueueTryEnqueueDequeue(t *testing.T) {
 	q := NewMPMCQueue[int](10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if !q.TryEnqueue(i) {
 			t.Fatalf("failed to enqueue for %d", i)
 		}
 	}
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if got, ok := q.TryDequeue(); !ok || got != i {
 			t.Fatalf("got %v, want %d, for status %v", got, i, ok)
 		}
@@ -128,7 +128,7 @@ func hammerMPMCQueueNonBlockingCalls(t *testing.T, gomaxprocs, numOps, numThread
 	startwg.Add(1)
 	csum := make(chan int, numThreads)
 	// Start producers.
-	for i := 0; i < numThreads; i++ {
+	for i := range numThreads {
 		go func(n int) {
 			startwg.Wait()
 			for j := n; j < numOps; j += numThreads {
@@ -139,7 +139,7 @@ func hammerMPMCQueueNonBlockingCalls(t *testing.T, gomaxprocs, numOps, numThread
 		}(i)
 	}
 	// Start consumers.
-	for i := 0; i < numThreads; i++ {
+	for i := range numThreads {
 		go func(n int) {
 			startwg.Wait()
 			sum := 0
@@ -162,7 +162,7 @@ func hammerMPMCQueueNonBlockingCalls(t *testing.T, gomaxprocs, numOps, numThread
 	startwg.Done()
 	// Wait for all the sums from consumers.
 	sum := 0
-	for i := 0; i < numThreads; i++ {
+	for range numThreads {
 		s := <-csum
 		sum += s
 	}
@@ -198,8 +198,8 @@ func benchmarkMPMCQueue(b *testing.B, queueSize, localWork int) {
 		go func() {
 			foo := 0
 			for atomic.AddInt32(&N, -1) >= 0 {
-				for g := 0; g < callsPerSched; g++ {
-					for i := 0; i < localWork; i++ {
+				for range callsPerSched {
+					for range localWork {
 						foo *= 2
 						foo /= 2
 					}
@@ -230,7 +230,7 @@ func benchmarkMPMCQueue(b *testing.B, queueSize, localWork int) {
 				if v == 0 {
 					break
 				}
-				for i := 0; i < localWork; i++ {
+				for range localWork {
 					foo *= 2
 					foo /= 2
 				}

--- a/spscqueue_test.go
+++ b/spscqueue_test.go
@@ -22,12 +22,12 @@ func TestSPSCQueueOf_InvalidSize(t *testing.T) {
 
 func TestSPSCQueueOfTryEnqueueDequeueInt(t *testing.T) {
 	q := NewSPSCQueue[int](10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if !q.TryEnqueue(i) {
 			t.Fatal("TryEnqueue failed")
 		}
 	}
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if got, ok := q.TryDequeue(); !ok || got != i {
 			t.Fatalf("%v: got %v, want %d", ok, got, i)
 		}
@@ -36,12 +36,12 @@ func TestSPSCQueueOfTryEnqueueDequeueInt(t *testing.T) {
 
 func TestSPSCQueueOfTryEnqueueDequeueString(t *testing.T) {
 	q := NewSPSCQueue[string](10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if !q.TryEnqueue(strconv.Itoa(i)) {
 			t.Fatal("TryEnqueue failed")
 		}
 	}
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if got, ok := q.TryDequeue(); !ok || got != strconv.Itoa(i) {
 			t.Fatalf("%v: got %v, want %d", ok, got, i)
 		}
@@ -54,12 +54,12 @@ func TestSPSCQueueOfTryEnqueueDequeueStruct(t *testing.T) {
 		baz int
 	}
 	q := NewSPSCQueue[foo](10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if !q.TryEnqueue(foo{i, i}) {
 			t.Fatal("TryEnqueue failed")
 		}
 	}
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if got, ok := q.TryDequeue(); !ok || got.bar != i || got.baz != i {
 			t.Fatalf("%v: got %v, want %d", ok, got, i)
 		}
@@ -72,7 +72,7 @@ func TestSPSCQueueOfTryEnqueueDequeueStructRef(t *testing.T) {
 		baz int
 	}
 	q := NewSPSCQueue[*foo](11)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if !q.TryEnqueue(&foo{i, i}) {
 			t.Fatal("TryEnqueue failed")
 		}
@@ -80,7 +80,7 @@ func TestSPSCQueueOfTryEnqueueDequeueStructRef(t *testing.T) {
 	if !q.TryEnqueue(nil) {
 		t.Fatal("TryEnqueue with nil failed")
 	}
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if got, ok := q.TryDequeue(); !ok || got.bar != i || got.baz != i {
 			t.Fatalf("%v: got %v, want %d", ok, got, i)
 		}
@@ -92,12 +92,12 @@ func TestSPSCQueueOfTryEnqueueDequeueStructRef(t *testing.T) {
 
 func TestSPSCQueueOfTryEnqueueDequeue(t *testing.T) {
 	q := NewSPSCQueue[int](10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if !q.TryEnqueue(i) {
 			t.Fatalf("failed to enqueue for %d", i)
 		}
 	}
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if got, ok := q.TryDequeue(); !ok || got != i {
 			t.Fatalf("got %v, want %d, for status %v", got, i, ok)
 		}
@@ -129,7 +129,7 @@ func hammerSPSCQueueOfNonBlockingCalls(t *testing.T, cap, numOps int) {
 	// Start producer.
 	go func() {
 		startwg.Wait()
-		for j := 0; j < numOps; j++ {
+		for j := range numOps {
 			for !q.TryEnqueue(j) {
 				// busy spin until success
 			}
@@ -139,7 +139,7 @@ func hammerSPSCQueueOfNonBlockingCalls(t *testing.T, cap, numOps int) {
 	go func() {
 		startwg.Wait()
 		sum := 0
-		for j := 0; j < numOps; j++ {
+		for range numOps {
 			var (
 				item int
 				ok   bool
@@ -184,8 +184,8 @@ func benchmarkSPSCQueueOfProdCons(b *testing.B, queueSize, localWork int) {
 	go func() {
 		foo := 0
 		for atomic.AddInt32(&N, -1) >= 0 {
-			for g := 0; g < callsPerSched; g++ {
-				for i := 0; i < localWork; i++ {
+			for range callsPerSched {
+				for range localWork {
 					foo *= 2
 					foo /= 2
 				}
@@ -206,7 +206,7 @@ func benchmarkSPSCQueueOfProdCons(b *testing.B, queueSize, localWork int) {
 				if v == 0 {
 					break
 				}
-				for i := 0; i < localWork; i++ {
+				for range localWork {
 					foo *= 2
 					foo /= 2
 				}
@@ -238,8 +238,8 @@ func benchmarkSPSCChan(b *testing.B, chanSize, localWork int) {
 	go func() {
 		foo := 0
 		for atomic.AddInt32(&N, -1) >= 0 {
-			for g := 0; g < callsPerSched; g++ {
-				for i := 0; i < localWork; i++ {
+			for range callsPerSched {
+				for range localWork {
 					foo *= 2
 					foo /= 2
 				}
@@ -257,7 +257,7 @@ func benchmarkSPSCChan(b *testing.B, chanSize, localWork int) {
 			if v == 0 {
 				break
 			}
-			for i := 0; i < localWork; i++ {
+			for range localWork {
 				foo *= 2
 				foo /= 2
 			}

--- a/umpscqueue_test.go
+++ b/umpscqueue_test.go
@@ -11,10 +11,10 @@ import (
 
 func TestUMPSCQueueEnqueueDequeueInt(t *testing.T) {
 	q := NewUMPSCQueue[int]()
-	for i := 0; i < 10000; i++ {
+	for i := range 10000 {
 		q.Enqueue(i)
 	}
-	for i := 0; i < 10000; i++ {
+	for i := range 10000 {
 		if got := q.Dequeue(); got != i {
 			t.Fatalf("got %v, want %d", got, i)
 		}
@@ -23,10 +23,10 @@ func TestUMPSCQueueEnqueueDequeueInt(t *testing.T) {
 
 func TestUMPSCQueueEnqueueDequeueString(t *testing.T) {
 	q := NewUMPSCQueue[string]()
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		q.Enqueue(strconv.Itoa(i))
 	}
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		if got := q.Dequeue(); got != strconv.Itoa(i) {
 			t.Fatalf("got %v, want %d", got, i)
 		}
@@ -39,10 +39,10 @@ func TestUMPSCQueueEnqueueDequeueStruct(t *testing.T) {
 		baz int
 	}
 	q := NewUMPSCQueue[foo]()
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		q.Enqueue(foo{i, i})
 	}
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		if got := q.Dequeue(); got.bar != i || got.baz != i {
 			t.Fatalf("got %v, want %d", got, i)
 		}
@@ -55,11 +55,11 @@ func TestUMPSCQueueEnqueueDequeueStructRef(t *testing.T) {
 		baz int
 	}
 	q := NewUMPSCQueue[*foo]()
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		q.Enqueue(&foo{i, i})
 	}
 	q.Enqueue(nil)
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		if got := q.Dequeue(); got.bar != i || got.baz != i {
 			t.Fatalf("got %v, want %d", got, i)
 		}
@@ -108,7 +108,7 @@ func hammerUMPSCQueueBlockingCalls(t *testing.T, gomaxprocs, numOps, numThreads 
 	startwg.Add(1)
 	csum := make(chan int, 1)
 	// Start producers.
-	for i := 0; i < numThreads; i++ {
+	for i := range numThreads {
 		go func(n int) {
 			startwg.Wait()
 			for j := n; j < numOps; j += numThreads {
@@ -120,7 +120,7 @@ func hammerUMPSCQueueBlockingCalls(t *testing.T, gomaxprocs, numOps, numThreads 
 	go func() {
 		startwg.Wait()
 		sum := 0
-		for i := 0; i < numOps; i++ {
+		for range numOps {
 			item := q.Dequeue()
 			sum += item
 		}
@@ -161,7 +161,7 @@ func BenchmarkChanVsUMPSCQueue(b *testing.B) {
 		done := make(chan struct{})
 		go func() {
 			defer close(done)
-			for range b.N {
+			for b.Loop() {
 				q.Dequeue()
 			}
 		}()

--- a/util_test.go
+++ b/util_test.go
@@ -29,7 +29,7 @@ func TestCheaprand(t *testing.T) {
 	count := 100
 	set := make(map[uint32]struct{}, count)
 
-	for i := 0; i < count; i++ {
+	for range count {
 		num := Cheaprand()
 		set[num] = struct{}{}
 	}
@@ -269,14 +269,14 @@ func TestSetByte(t *testing.T) {
 }
 
 func BenchmarkCheaprand(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = Cheaprand()
 	}
 	// <1.4 ns/op on x86-64
 }
 
 func BenchmarkRand(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = rand.Uint32()
 	}
 	// about 5 ns/op on x86-64


### PR DESCRIPTION
This small MR is just the result of calling modernize[0] on the codebase.

It does have some effect on the benchmarks, though: the new b.Loop() way of disables more optimizations and so causes "worse" benchmark results, though I'd say they are more realistic. WDYT?

[0] https://golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize