### PR TITLE
feat: branchless

### DIFF
--- a/map.go
+++ b/map.go
@@ -718,12 +718,8 @@ func (m *Map[K, V]) doCompute(
 							newv = oldv
 						}
 						rootb.mu.Unlock()
-						if computeOnly {
-							// Compute expects the new value to be returned.
-							return newv, true
-						}
-						// LoadAndStore expects the old value to be returned.
-						return oldv, true
+						rv := [2]V{oldv, newv}
+						return rv[Bool2int(computeOnly)], true
 					}
 				}
 				markedw &= markedw - 1
@@ -1336,15 +1332,12 @@ func (m *Map[K, V]) Stats() MapStats {
 			nentriesLocal := 0
 			stats.Capacity += entriesPerMapBucket
 			for i := range entriesPerMapBucket {
-				if atomic.LoadPointer(&b.entries[i]) != nil {
-					stats.Size++
-					nentriesLocal++
-				}
+				occupied := Bool2int(atomic.LoadPointer(&b.entries[i]) != nil)
+				stats.Size += occupied
+				nentriesLocal += occupied
 			}
 			nentries += nentriesLocal
-			if nentriesLocal == 0 {
-				stats.EmptyBuckets++
-			}
+			stats.EmptyBuckets += Bool2int(nentriesLocal == 0)
 			if b.next == nil {
 				break
 			}

--- a/util.go
+++ b/util.go
@@ -3,6 +3,7 @@ package xsync
 import (
 	"math/bits"
 	"runtime"
+	"unsafe"
 	_ "unsafe"
 )
 
@@ -64,4 +65,11 @@ func markZeroBytes(w uint64) uint64 {
 func setByte(w uint64, b uint8, idx int) uint64 {
 	shift := idx << 3
 	return (w &^ (0xff << shift)) | (uint64(b) << shift)
+}
+
+// Bool2int returns 0 if x is false or 1 if x is true.
+func Bool2int(x bool) int {
+	// Avoid branches. In the SSA compiler, this compiles to
+	// exactly what you would want it to.
+	return int(*(*uint8)(unsafe.Pointer(&x)))
 }


### PR DESCRIPTION
```
                                                 │ map_ops_no_branchless │         map_ops_branchless          │
                                                 │        sec/op         │   sec/op     vs base                │
Map_NoWarmUp/reads=99%-12                                   7.630n ±  9%   6.441n ± 2%  -15.57% (p=0.000 n=10)
Map_NoWarmUp/reads=90%-12                                  10.180n ± 11%   9.777n ± 4%        ~ (p=0.052 n=10)
Map_NoWarmUp/reads=75%-12                                   13.94n ±  4%   13.55n ± 5%        ~ (p=0.190 n=10)
Map_WarmUp/reads=100%-12                                    6.429n ±  7%   6.230n ± 1%   -3.10% (p=0.000 n=10)
Map_WarmUp/reads=99%-12                                     6.564n ±  6%   6.123n ± 1%   -6.71% (p=0.001 n=10)
Map_WarmUp/reads=90%-12                                     8.311n ±  1%   8.312n ± 1%        ~ (p=0.838 n=10)
Map_WarmUp/reads=75%-12                                     11.37n ±  2%   11.41n ± 1%        ~ (p=0.323 n=10)
MapInt_NoWarmUp/reads=99%-12                                4.087n ±  5%   3.985n ± 3%   -2.48% (p=0.037 n=10)
MapInt_NoWarmUp/reads=90%-12                                7.213n ± 34%   6.729n ± 3%   -6.71% (p=0.023 n=10)
MapInt_NoWarmUp/reads=75%-12                               11.815n ± 11%   9.868n ± 3%  -16.47% (p=0.000 n=10)
MapInt_WarmUp/reads=100%-12                                 2.795n ± 10%   2.558n ± 2%   -8.50% (p=0.000 n=10)
MapInt_WarmUp/reads=99%-12                                  4.627n ±  8%   3.764n ± 4%  -18.64% (p=0.000 n=10)
MapInt_WarmUp/reads=90%-12                                  6.904n ±  6%   5.700n ± 1%  -17.45% (p=0.000 n=10)
MapInt_WarmUp/reads=75%-12                                  8.564n ±  9%   8.309n ± 1%   -2.98% (p=0.002 n=10)
MapRange-12                                                 4.956µ ±  3%   4.926µ ± 1%        ~ (p=0.280 n=10)
MapRangeRelaxed-12                                          735.5n ±  1%   722.0n ± 0%   -1.84% (p=0.002 n=10)
MapCompute/op=UpdateOp-12                                   43.44n ±  5%   44.06n ± 8%        ~ (p=0.123 n=10)
MapCompute/op=CancelOp-12                                   27.32n ±  2%   26.89n ± 1%   -1.56% (p=0.002 n=10)
MapParallelRehashing/1goroutine_10M-12                       2.513 ±  2%    2.431 ± 1%   -3.26% (p=0.000 n=10)
MapParallelRehashing/4goroutines_10M-12                     943.2m ±  1%   897.2m ± 3%   -4.88% (p=0.002 n=10)
MapParallelRehashing/8goroutines_10M-12                     724.3m ±  2%   702.0m ± 9%   -3.07% (p=0.023 n=10)
MapDeleteMatching/entries=1000_delete=10%-12                91.70µ ±  3%   88.88µ ± 0%   -3.08% (p=0.000 n=10)
MapDeleteMatching/entries=1000_delete=50%-12                96.55µ ±  1%   94.98µ ± 1%   -1.63% (p=0.000 n=10)
MapDeleteMatching/entries=1000_delete=100%-12               105.4µ ±  1%   103.8µ ± 1%   -1.49% (p=0.000 n=10)
MapDeleteMatching/entries=100000_delete=10%-12             10.034m ±  2%   9.565m ± 1%   -4.67% (p=0.000 n=10)
MapDeleteMatching/entries=100000_delete=50%-12              11.00m ±  2%   10.29m ± 2%   -6.43% (p=0.000 n=10)
MapDeleteMatching/entries=100000_delete=100%-12             11.18m ± 11%   10.86m ± 1%   -2.90% (p=0.000 n=10)
MapDeleteMatching/entries=1000000_delete=10%-12             157.7m ±  3%   156.7m ± 2%        ~ (p=0.190 n=10)
MapDeleteMatching/entries=1000000_delete=50%-12             174.1m ±  3%   171.2m ± 1%   -1.64% (p=0.009 n=10)
MapDeleteMatching/entries=1000000_delete=100%-12            185.4m ±  6%   171.2m ± 2%   -7.64% (p=0.000 n=10)
MapRangeDelete/entries=1000_delete=10%-12                   95.08µ ±  3%   94.23µ ± 0%   -0.90% (p=0.015 n=10)
MapRangeDelete/entries=1000_delete=50%-12                   114.5µ ±  1%   113.5µ ± 0%   -0.87% (p=0.002 n=10)
MapRangeDelete/entries=1000_delete=100%-12                  139.7µ ±  0%   139.2µ ± 1%   -0.38% (p=0.043 n=10)
MapRangeDelete/entries=100000_delete=10%-12                10.094m ±  2%   9.910m ± 1%   -1.82% (p=0.002 n=10)
MapRangeDelete/entries=100000_delete=50%-12                 12.36m ±  7%   12.02m ± 1%   -2.73% (p=0.000 n=10)
MapRangeDelete/entries=100000_delete=100%-12                15.56m ±  1%   14.54m ± 1%   -6.60% (p=0.000 n=10)
MapRangeDelete/entries=1000000_delete=10%-12                164.7m ±  7%   160.8m ± 3%   -2.36% (p=0.043 n=10)
MapRangeDelete/entries=1000000_delete=50%-12                197.8m ±  2%   193.5m ± 2%   -2.20% (p=0.005 n=10)
MapRangeDelete/entries=1000000_delete=100%-12               242.2m ±  9%   219.2m ± 1%   -9.48% (p=0.000 n=10)
geomean                                                     24.34µ         23.21µ        -4.65%
```