### PR TITLE
Fix trivial hash flooding in integer hash function

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -43,3 +43,7 @@ func SetByte(w uint64, b uint8, idx int) uint64 {
 func NextPowOf2(v uint32) uint32 {
 	return nextPowOf2(v)
 }
+
+func HashUint64(seed, v uint64) uint64 {
+	return hashUint64(seed, v)
+}

--- a/map.go
+++ b/map.go
@@ -239,13 +239,15 @@ func detectIntKey[K comparable]() bool {
 	}
 }
 
-// hashUint64 computes a hash for integer keys using a 128-bit
-// multiply-xorshift mixer (wyhash-style). The constant is xxHash's
-// PRIME64_1 which provides excellent avalanche. This is significantly
-// faster than maphash.Comparable for integer types.
+// hashUint64 computes a hash for integer keys using two rounds of
+// multiply-xorshift mixing (wyhash-style). The second round eliminates
+// the seed-independent differential bias present in a single-round
+// mixer (see https://github.com/puzpuzpuz/xsync/issues/192).
+// This is significantly faster than maphash.Comparable for integer types.
 func hashUint64(seed, v uint64) uint64 {
-	hi, lo := bits.Mul64(v^seed, 0x9E3779B185EBCA87)
-	return hi ^ lo
+	hi, lo := bits.Mul64(v^seed, 0x2d358dccaa6c78a5)
+	hi2, lo2 := bits.Mul64(hi^lo, 0x8bb84b93962eacc9)
+	return hi2 ^ lo2
 }
 
 // toUint64 reinterprets integer-like keys as uint64 for hashUint64.

--- a/map.go
+++ b/map.go
@@ -240,9 +240,7 @@ func detectIntKey[K comparable]() bool {
 }
 
 // hashUint64 computes a hash for integer keys using two rounds of
-// multiply-xorshift mixing (wyhash-style). The second round eliminates
-// the seed-independent differential bias present in a single-round
-// mixer (see https://github.com/puzpuzpuz/xsync/issues/192).
+// multiply-xorshift mixing (wyhash-style).
 // This is significantly faster than maphash.Comparable for integer types.
 func hashUint64(seed, v uint64) uint64 {
 	hi, lo := bits.Mul64(v^seed, 0x2d358dccaa6c78a5)

--- a/map_test.go
+++ b/map_test.go
@@ -95,6 +95,41 @@ func TestMap_EmptyStringKey(t *testing.T) {
 	}
 }
 
+// TestMapHashUint64_NoDifferentialBias verifies that hashUint64 does
+// not exhibit seed-independent differential bias for XOR deltas
+// (see https://github.com/puzpuzpuz/xsync/issues/192).
+func TestMapHashUint64_NoDifferentialBias(t *testing.T) {
+	const (
+		nBuckets = 256
+		mask     = nBuckets - 1
+		nTrials  = 100_000
+	)
+	expected := float64(nTrials) / float64(nBuckets)
+	// Worst delta from the issue report plus a few more.
+	deltas := []uint64{
+		0x0000015000000000,
+		0x0000004F00000000,
+		0x000000A300000000,
+		0x00000D0000000000,
+	}
+	seed := uint64(42)
+	for _, delta := range deltas {
+		collisions := 0
+		for i := 0; i < nTrials; i++ {
+			v := uint64(i) * 0x9E3779B97F4A7C15 // spread values
+			h1 := HashUint64(seed, v)
+			h2 := HashUint64(seed, v^delta)
+			if (h1 & mask) == (h2 & mask) {
+				collisions++
+			}
+		}
+		ratio := float64(collisions) / expected
+		if ratio > 2.0 {
+			t.Errorf("differential bias for delta=0x%x: got %.2fx expected collision rate", delta, ratio)
+		}
+	}
+}
+
 func TestMapStore_NilValue(t *testing.T) {
 	m := NewMap[string, *struct{}]()
 	m.Store("foo", nil)

--- a/map_test.go
+++ b/map_test.go
@@ -100,32 +100,63 @@ func TestMap_EmptyStringKey(t *testing.T) {
 // (see https://github.com/puzpuzpuz/xsync/issues/192).
 func TestMapHashUint64_NoDifferentialBias(t *testing.T) {
 	const (
-		nBuckets = 256
-		mask     = nBuckets - 1
-		nTrials  = 100_000
+		nBuckets  = 256
+		mask      = nBuckets - 1
+		nTrials   = 100_000
+		threshold = 3.0
 	)
 	expected := float64(nTrials) / float64(nBuckets)
-	// Worst delta from the issue report plus a few more.
-	deltas := []uint64{
+
+	// Deltas from the issue report.
+	issueDeltas := []uint64{
 		0x0000015000000000,
 		0x0000004F00000000,
 		0x000000A300000000,
 		0x00000D0000000000,
 	}
-	seed := uint64(42)
-	for _, delta := range deltas {
-		collisions := 0
-		for i := 0; i < nTrials; i++ {
-			v := uint64(i) * 0x9E3779B97F4A7C15 // spread values
-			h1 := HashUint64(seed, v)
-			h2 := HashUint64(seed, v^delta)
-			if (h1 & mask) == (h2 & mask) {
-				collisions++
-			}
+	// Structured deltas across various shift amounts.
+	var shiftedDeltas []uint64
+	for _, shift := range []uint{0, 8, 16, 24, 32, 40, 48} {
+		for k := uint64(1); k <= 64; k++ {
+			shiftedDeltas = append(shiftedDeltas, k<<shift)
 		}
-		ratio := float64(collisions) / expected
-		if ratio > 2.0 {
-			t.Errorf("differential bias for delta=0x%x: got %.2fx expected collision rate", delta, ratio)
+	}
+	// Single-bit and two-bit (Hamming distance 1-2) deltas.
+	var hammingDeltas []uint64
+	for b := 0; b < 64; b++ {
+		hammingDeltas = append(hammingDeltas, 1<<b)
+	}
+	for b1 := 0; b1 < 64; b1 += 4 {
+		for b2 := b1 + 1; b2 < 64; b2 += 4 {
+			hammingDeltas = append(hammingDeltas, (1<<b1)|(1<<b2))
+		}
+	}
+
+	allDeltas := make([]uint64, 0, len(issueDeltas)+len(shiftedDeltas)+len(hammingDeltas))
+	allDeltas = append(allDeltas, issueDeltas...)
+	allDeltas = append(allDeltas, shiftedDeltas...)
+	allDeltas = append(allDeltas, hammingDeltas...)
+
+	seeds := []uint64{0, 42, 0xDEADBEEF}
+	for _, seed := range seeds {
+		for _, delta := range allDeltas {
+			if delta == 0 {
+				continue
+			}
+			collisions := 0
+			for i := 0; i < nTrials; i++ {
+				v := uint64(i) * 0x9E3779B97F4A7C15 // spread values
+				h1 := HashUint64(seed, v)
+				h2 := HashUint64(seed, v^delta)
+				if (h1 & mask) == (h2 & mask) {
+					collisions++
+				}
+			}
+			ratio := float64(collisions) / expected
+			if ratio > threshold {
+				t.Errorf("seed=0x%x delta=0x%x: got %.2fx expected collision rate (threshold=%.1fx)",
+					seed, delta, ratio, threshold)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes #192

Performance penalty is around 7% in the 100% reads int keys benchmark.