### PR TITLE
Avoid false sharing in MPMCQueue

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,10 @@ Make sure to implement proper back-off strategy to handle failed optimistic oper
 ### MPMCQueue
 
 A `MPMCQueue` is a bounded multi-producer multi-consumer concurrent queue.
-Requested queue capacity is rounded up to the next power of 2.
 
 ```go
-q := xsync.NewMPMCQueue[string](1024)
+// capacity is rounded up to the next power of 2 (1000 -> 1024)
+q := xsync.NewMPMCQueue[string](1000)
 // producer optimistically inserts an item into the queue
 // optimistic insertion attempt; doesn't block
 inserted := q.TryEnqueue("bar")

--- a/counter.go
+++ b/counter.go
@@ -39,7 +39,7 @@ type cstripe struct {
 
 // NewCounter creates a new Counter instance.
 func NewCounter() *Counter {
-	nstripes := nextPowOf2(parallelism())
+	nstripes := uint32(nextPowOf2(uint64(parallelism())))
 	c := Counter{
 		stripes: make([]cstripe, nstripes),
 		mask:    nstripes - 1,

--- a/export_test.go
+++ b/export_test.go
@@ -1,11 +1,12 @@
 package xsync
 
 const (
-	EntriesPerMapBucket   = entriesPerMapBucket
-	MapLoadFactor         = mapLoadFactor
-	DefaultMinMapTableLen = defaultMinMapTableLen
-	DefaultMinMapTableCap = defaultMinMapTableLen * entriesPerMapBucket
-	MaxMapCounterLen      = maxMapCounterLen
+	EntriesPerMapBucket           = entriesPerMapBucket
+	MapLoadFactor                 = mapLoadFactor
+	DefaultMinMapTableLen         = defaultMinMapTableLen
+	DefaultMinMapTableCap         = defaultMinMapTableLen * entriesPerMapBucket
+	MaxMapCounterLen              = maxMapCounterLen
+	MpmcQueueMaxRequestedCapacity = mpmcQueueMaxRequestedCapacity
 )
 
 type (
@@ -40,7 +41,7 @@ func SetByte(w uint64, b uint8, idx int) uint64 {
 	return setByte(w, b, idx)
 }
 
-func NextPowOf2(v uint32) uint32 {
+func NextPowOf2(v uint64) uint64 {
 	return nextPowOf2(v)
 }
 

--- a/map.go
+++ b/map.go
@@ -219,7 +219,7 @@ func NewMap[K comparable, V any](options ...func(*MapConfig)) *Map[K, V] {
 	if c.sizeHint <= defaultMinMapTableLen*entriesPerMapBucket {
 		table = newMapTable[K, V](defaultMinMapTableLen, maphash.MakeSeed())
 	} else {
-		tableLen := nextPowOf2(uint32((float64(c.sizeHint) / entriesPerMapBucket) / mapLoadFactor))
+		tableLen := nextPowOf2(uint64((float64(c.sizeHint) / entriesPerMapBucket) / mapLoadFactor))
 		table = newMapTable[K, V](int(tableLen), maphash.MakeSeed())
 	}
 	m.minTableLen = len(table.buckets)

--- a/mpmcqueue.go
+++ b/mpmcqueue.go
@@ -6,7 +6,7 @@ import (
 	"unsafe"
 )
 
-const MpmcQueueMaxRequestedCapacity uint64 = uint64(1) << (bits.UintSize - 2)
+const mpmcQueueMaxRequestedCapacity uint64 = uint64(1) << (bits.UintSize - 2)
 
 // Deprecated: use [MPMCQueue].
 type MPMCQueueOf[I any] = MPMCQueue[I]
@@ -60,10 +60,10 @@ func NewMPMCQueue[I any](capacity int) *MPMCQueue[I] {
 	if capacity < 1 {
 		panic("capacity must be positive number")
 	}
-	if uint64(capacity) > MpmcQueueMaxRequestedCapacity {
+	if uint64(capacity) > mpmcQueueMaxRequestedCapacity {
 		panic("capacity is too large")
 	}
-	capPow2 := nextPowOf2_64(uint64(capacity))
+	capPow2 := nextPowOf2(uint64(capacity))
 	return &MPMCQueue[I]{
 		cap:     capPow2,
 		mask:    capPow2 - 1,

--- a/mpmcqueue.go
+++ b/mpmcqueue.go
@@ -20,12 +20,12 @@ type MPMCQueueOf[I any] = MPMCQueue[I]
 // Based on the data structure from the following C++ library:
 // https://github.com/rigtorp/MPMCQueue
 type MPMCQueue[I any] struct {
-	cap     uint64
-	mask    uint64
-	capLog2 uint64
-	head    uint64
-	// Padding to prevent false sharing.
-	_     [cacheLineSize - 32]byte
+	capMask  uint64
+	capShift uint64
+	// Padding to isolate read-only fields from the head/tail counters.
+	_     [cacheLineSize - 16]byte
+	head  uint64
+	_     [cacheLineSize - 8]byte
 	tail  uint64
 	_     [cacheLineSize - 8]byte
 	slots []slotPadded[I]
@@ -65,9 +65,8 @@ func NewMPMCQueue[I any](capacity int) *MPMCQueue[I] {
 	}
 	capPow2 := nextPowOf2(uint64(capacity))
 	return &MPMCQueue[I]{
-		cap:     capPow2,
-		mask:    capPow2 - 1,
-		capLog2: uint64(bits.TrailingZeros64(capPow2)),
+		capMask: capPow2 - 1,
+		capShift: uint64(bits.TrailingZeros64(capPow2)),
 		slots:   make([]slotPadded[I], capPow2),
 	}
 }
@@ -110,9 +109,9 @@ func (q *MPMCQueue[I]) TryDequeue() (item I, ok bool) {
 }
 
 func (q *MPMCQueue[I]) idx(i uint64) uint64 {
-	return i & q.mask
+	return i & q.capMask
 }
 
 func (q *MPMCQueue[I]) turn(i uint64) uint64 {
-	return i >> q.capLog2
+	return i >> q.capShift
 }

--- a/mpmcqueue.go
+++ b/mpmcqueue.go
@@ -65,9 +65,9 @@ func NewMPMCQueue[I any](capacity int) *MPMCQueue[I] {
 	}
 	capPow2 := nextPowOf2(uint64(capacity))
 	return &MPMCQueue[I]{
-		capMask: capPow2 - 1,
+		capMask:  capPow2 - 1,
 		capShift: uint64(bits.TrailingZeros64(capPow2)),
-		slots:   make([]slotPadded[I], capPow2),
+		slots:    make([]slotPadded[I], capPow2),
 	}
 }
 

--- a/rbmutex.go
+++ b/rbmutex.go
@@ -55,7 +55,7 @@ type rslot struct {
 
 // NewRBMutex creates a new RBMutex instance.
 func NewRBMutex() *RBMutex {
-	nslots := nextPowOf2(parallelism())
+	nslots := uint32(nextPowOf2(uint64(parallelism())))
 	mu := RBMutex{
 		rslots: make([]rslot, nslots),
 		rmask:  nslots - 1,

--- a/util.go
+++ b/util.go
@@ -17,24 +17,8 @@ const (
 	cacheLineSize = 64
 )
 
-// nextPowOf2 computes the next highest power of 2 of 32-bit v.
-// Source: https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
-func nextPowOf2(v uint32) uint32 {
-	if v == 0 {
-		return 1
-	}
-	v--
-	v |= v >> 1
-	v |= v >> 2
-	v |= v >> 4
-	v |= v >> 8
-	v |= v >> 16
-	v++
-	return v
-}
-
-// nextPowOf2_64 computes the next highest power of 2 of 64-bit v.
-func nextPowOf2_64(v uint64) uint64 {
+// nextPowOf2 computes the next highest power of 2 of 64-bit v.
+func nextPowOf2(v uint64) uint64 {
 	if v <= 1 {
 		return 1
 	}


### PR DESCRIPTION
A follow-up for #200

* Isolates read-only fields in `MPMCQueue` to their own cache line
* Removes the old `nextPowOf2` function in favor of the 64-bit one
* Renames read-only fields in `MPMCQueue`

### Microbenchmarks

**Test stand:** AMD Ryzen 9 7900 (12 cores / 24 threads), Linux, Go 1.26.0, amd64. Benchmarks run with `-count=10 -benchtime=1s`; comparison via `benchstat` (p=0.000 on both rows).

| Benchmark | Baseline | New | Δ |
|---|---|---|---|
| `MPMCQueue` (no work) | 42.73 ns/op | 17.50 ns/op | -59% |
| `MPMCQueueWork100` | 153.8 ns/op | 111.0 ns/op | -28% |