### PR TITLE
fix: release bucket lock when Compute callback panics

### DIFF
--- a/map.go
+++ b/map.go
@@ -585,6 +585,19 @@ func (m *Map[K, V]) doCompute(
 	loadOp loadOp,
 	computeOnly bool,
 ) (V, bool) {
+	// callValueFn invokes valueFn while holding mu. If valueFn panics, the
+	// mutex is released before the panic propagates so that the bucket does
+	// not stay permanently locked.
+	callValueFn := func(mu *sync.Mutex, oldv V, loaded bool) (newv V, op ComputeOp) {
+		defer func() {
+			if r := recover(); r != nil {
+				mu.Unlock()
+				panic(r)
+			}
+		}()
+		return valueFn(oldv, loaded)
+	}
+
 	for {
 	compute_attempt:
 		var (
@@ -666,7 +679,7 @@ func (m *Map[K, V]) doCompute(
 						// snapshot won't be correct in case of multiple Store calls
 						// using the same value.
 						oldv := e.value
-						newv, op := valueFn(oldv, true)
+						newv, op := callValueFn(&rootb.mu, oldv, true)
 						switch op {
 						case DeleteOp:
 							// Deletion.
@@ -713,7 +726,7 @@ func (m *Map[K, V]) doCompute(
 				if emptyb != nil {
 					// Insertion into an existing bucket.
 					var zeroV V
-					newValue, op := valueFn(zeroV, false)
+					newValue, op := callValueFn(&rootb.mu, zeroV, false)
 					switch op {
 					case DeleteOp, CancelOp:
 						rootb.mu.Unlock()
@@ -739,7 +752,7 @@ func (m *Map[K, V]) doCompute(
 				}
 				// Insertion into a new bucket.
 				var zeroV V
-				newValue, op := valueFn(zeroV, false)
+				newValue, op := callValueFn(&rootb.mu, zeroV, false)
 				switch op {
 				case DeleteOp, CancelOp:
 					rootb.mu.Unlock()

--- a/map_test.go
+++ b/map_test.go
@@ -2071,6 +2071,37 @@ func TestToPlainMap(t *testing.T) {
 	}
 }
 
+func TestMapComputePanicReleasesLock(t *testing.T) {
+	// Verify that a panic inside the Compute callback releases the bucket lock.
+	// If the lock is leaked, the second Compute call on the same key deadlocks.
+	m := NewMap[string, int]()
+	m.Store("k", 1)
+
+	// A panic in the compute function, recovered by the caller.
+	func() {
+		defer func() { _ = recover() }()
+		m.Compute("k", func(old int, loaded bool) (int, ComputeOp) {
+			panic("at the disco")
+		})
+	}()
+
+	// Touch the same key again; deadlocks forever if the bucket lock was leaked.
+	done := make(chan struct{})
+	go func() {
+		m.Compute("k", func(old int, loaded bool) (int, ComputeOp) {
+			return old + 1, UpdateOp
+		})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// lock was released correctly
+	case <-time.After(2 * time.Second):
+		t.Fatal("deadlock: bucket lock was not released after a panicking Compute callback")
+	}
+}
+
 func BenchmarkMap_NoWarmUp(b *testing.B) {
 	for _, bc := range benchmarkCases {
 		if bc.readPercentage == 100 {


### PR DESCRIPTION
## Problem

If the function passed to `Map.Compute` (or `LoadOrCompute`) panics, the
bucket's `sync.Mutex` is never released. The panic can be recovered by
the caller, but the mutex stays locked, so every subsequent operation
whose key maps to that bucket deadlocks forever.

Reported in #208.

## Root cause

`doCompute` locks `rootb.mu` and then calls `valueFn` in three places
(update-in-place, insert-into-existing-bucket, insert-into-new-bucket).
If `valueFn` panics, none of the explicit `rootb.mu.Unlock()` calls that
follow it are reached, leaving the lock permanently held.

## Fix

Wrap each `valueFn` invocation in a small helper `callValueFn` that
defers a `recover`. If the callback panics, the helper unlocks the mutex
before re-panicking, so the panic propagates to the caller unchanged
while the bucket lock is always released.

```go
callValueFn := func(mu *sync.Mutex, oldv V, loaded bool) (newv V, op ComputeOp) {
    defer func() {
        if r := recover(); r != nil {
            mu.Unlock()
            panic(r)
        }
    }()
    return valueFn(oldv, loaded)
}
```

## Test

`TestMapComputePanicReleasesLock` reproduces the deadlock:

1. Store a key.
2. Call `Compute` on that key with a panicking callback; recover the panic.
3. Call `Compute` on the same key again in a goroutine.
4. Assert the second call completes within 2 s — it deadlocks forever without the fix.

All existing tests continue to pass.